### PR TITLE
1.0.a

### DIFF
--- a/lib/cequel/metal/inserter.rb
+++ b/lib/cequel/metal/inserter.rb
@@ -12,7 +12,7 @@ module Cequel
       def execute
         statement = Statement.new
         write_to_statement(statement)
-        data_set.execute_cql(*statement.args)
+        data_set.write(*statement.args)
       end
 
       def insert(data)

--- a/lib/cequel/model/base.rb
+++ b/lib/cequel/model/base.rb
@@ -40,10 +40,16 @@ module Cequel
 
       private
 
-      def initialize_new_record
+      def initialize_new_record(*args)
         @attributes = Marshal.load(Marshal.dump(default_attributes))
         @new_record = true
         yield self if block_given?
+        if Hash === args.first
+          args.first.each_pair do |k, v|
+            self.send("#{k}=", v)
+          end
+        end
+        self
       end
 
     end

--- a/lib/cequel/model/schema.rb
+++ b/lib/cequel/model/schema.rb
@@ -25,6 +25,10 @@ module Cequel
           @local_key_column ||= table_schema.key_columns.last
         end
 
+        def primary_keys
+          @primary_keys ||= table_schema.partition_keys + table_schema.clustering_columns
+        end
+
       end
 
     end

--- a/lib/cequel/model/scope.rb
+++ b/lib/cequel/model/scope.rb
@@ -59,7 +59,7 @@ module Cequel
         batch_size = options.fetch(:batch_size, 1000)
         base_batch_data_set = data_set.limit(options.fetch(:batch_size, 1000))
         batch_data_set = base_batch_data_set
-        key_column = clazz.local_key_column.name
+        key_column = clazz.primary_keys.first.name
         begin
           batch = batch_data_set.entries
           yield batch

--- a/spec/examples/model/compound_spec.rb
+++ b/spec/examples/model/compound_spec.rb
@@ -1,0 +1,145 @@
+require File.expand_path('../spec_helper', __FILE__)
+
+describe Cequel::Model::Persistence do
+  model :Post do
+    key :blog_subdomain, :text
+    key :permalink, :text
+    column :title, :text
+    column :body, :text
+    column :author_id, :uuid
+    list :tags, :text
+    set :categories, :text
+    map :shares, :text, :int
+  end
+
+  describe 'reading' do
+    before do
+      cequel[:posts].insert(
+        :blog_subdomain => 'cassandra',
+        :permalink => 'cequel',
+        :title => 'Cequel',
+        :tags => %w(big-data cql),
+        :categories => Set['Big Data', 'CQL'],
+        :shares => {'facebook' => 1}
+      )
+    end
+
+    describe '::find' do
+      subject { Post.find(:blog_subdomain => 'cassandra', :permalink => 'cequel') }
+
+      its(:blog_subdomain) { should == 'cassandra' }
+      its(:permalink) { should == 'cequel' }
+      its(:title) { should == 'Cequel' }
+      its(:tags) { should == %w(big-data cql) }
+      its(:categories) { should == Set['Big Data', 'CQL'] }
+      its(:shares) { should == {'facebook' => 1} }
+
+      it { should be_persisted }
+      it { should_not be_transient }
+      specify { Post.new.should_not be_persisted }
+      specify { Post.new.should be_transient }
+
+      specify do
+        expect { Post.find(:blog_subdomain => 'bogus')}.
+          to raise_error(Cequel::Model::RecordNotFound)
+        expect { Post.find(:blog_subdomain => 'bogus', :permalink => 'cequel') }.
+          to raise_error(Cequel::Model::RecordNotFound)
+      end
+    end
+
+    describe '::[]' do
+      subject { Post[:blog_subdomain => 'cassandra', :permalink => 'cequel'] }
+
+      it 'should not query the database' do
+        expect(cequel).not_to receive(:execute)
+        subject.blog_subdomain.should == 'cassandra'
+        subject.permalink.should == 'cequel'
+      end
+
+      it 'should lazily query the database when attribute accessed' do
+        subject.title.should == 'Cequel'
+      end
+
+      it 'should get all eager-loadable attributes on first lazy load' do
+        subject.title
+        expect(cequel).not_to receive(:execute)
+        subject.tags.should == %w(big-data cql)
+      end
+    end
+    
+    describe '::new' do
+      subject { Post.new(:blog_subdomain => 'cassandra', :permalink => 'cequel') }
+
+      it 'should not query the database' do
+        expect(cequel).not_to receive(:execute)
+        subject.blog_subdomain.should == 'cassandra'
+        subject.permalink.should == 'cequel'
+      end
+
+      it 'should not query the database when attribute accessed' do
+        expect(cequel).not_to receive(:execute)
+        subject.title.should == nil
+      end
+    end
+  end
+
+  describe 'writing' do
+    subject { cequel[:posts].where(:blog_subdomain => 'cassandra', :permalink => 'cequel').first }
+
+    let!(:post) do
+      Post.new do |post|
+        post.blog_subdomain = 'cassandra'
+        post.permalink = 'cequel'
+        post.title = 'Cequel'
+        post.body = 'A Ruby ORM for Cassandra 1.2'
+      end.tap(&:save)
+    end
+
+    describe '#save' do
+      context 'on create' do
+        it 'should save row to database' do
+          subject[:title].should == 'Cequel'
+        end
+
+        it 'should mark row persisted' do
+          post.should be_persisted
+        end
+      end
+
+      context 'on update' do
+        uuid :author_id
+
+        before do
+          post.title = 'Cequel 1.0'
+          post.author_id = author_id
+          post.body = nil
+          post.save
+        end
+
+        it 'should change existing column value' do
+          subject[:title].should == 'Cequel 1.0'
+        end
+
+        it 'should add new column value' do
+          subject[:author_id].should == author_id
+        end
+
+        it 'should remove old column values' do
+          subject[:body].should be_nil
+        end
+      end
+    end
+
+    describe '#destroy' do
+      before { post.destroy }
+
+      it 'should delete entire row' do
+        subject.should be_nil
+      end
+
+      it 'should mark record transient' do
+        post.should be_transient
+      end
+    end
+  end
+end


### PR DESCRIPTION
I've simply implemented compound key support feature. Please review my changes. To be honest, I can't understand why `Model::Schema::local_key_column` method uses last key column. So, I made new method `::primary_keys` for compound key feature.
And, I found that `Model::new` raise error when passed argument. `::new` method transfer arguments to `Model#intialize_new_record`, but this method cannot accept that argument. I thought that `::new` method's argument works like `ActiveRecord::new` mass-assignment. My implementation potentially has security issue, might be needed `attr_accessible` feature like ActiveRecord.
Finally, I think that `Inserter#execute` have to use `DataSet#write` like `Writer#execute`.
Please review and consider as a just reference. Thank you. :)
