### PR TITLE
Support ActiveModel and related ActiveRecord-like interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,10 +196,11 @@ the `categories` set.
 
 ### ActiveModel Support ###
 
-Cequel supports most ActiveModel functionality, such as callbacks, validations,
-naming, and serialization. If you're using Rails 3, mass-assignment protection
-works as usual, and in Rails 4, strong parameters are treated correctly. So we
-can add some extra ActiveModel goodness to our post model:
+Cequel supports ActiveModel functionality, such as callbacks, validations,
+dirty attribute tracking, naming, and serialization. If you're using Rails 3,
+mass-assignment protection works as usual, and in Rails 4, strong parameters are
+treated correctly. So we can add some extra ActiveModel goodness to our post
+model:
 
 ```ruby
 class Post < Cequel::Model::Base
@@ -217,6 +218,8 @@ end
 Note that validations or callbacks that need to read data attributes will cause
 unloaded models to load their row during the course of the save operation, so if
 you are following a write-without-reading pattern, you will need to be careful.
+
+Dirty attribute tracking is only enabled on loaded models.
 
 ### CQL Gotchas ###
 

--- a/lib/cequel/model.rb
+++ b/lib/cequel/model.rb
@@ -15,6 +15,7 @@ require 'cequel/model/has_many_association'
 require 'cequel/model/mass_assignment'
 require 'cequel/model/callbacks'
 require 'cequel/model/validations'
+require 'cequel/model/dirty'
 
 require 'cequel/model/base'
 

--- a/lib/cequel/model/base.rb
+++ b/lib/cequel/model/base.rb
@@ -12,6 +12,7 @@ module Cequel
       include Cequel::Model::MassAssignment
       include Cequel::Model::Callbacks
       include Cequel::Model::Validations
+      include Cequel::Model::Dirty
       extend ActiveModel::Naming
       include ActiveModel::Serializers::JSON
       include ActiveModel::Serializers::Xml

--- a/lib/cequel/model/collection.rb
+++ b/lib/cequel/model/collection.rb
@@ -10,6 +10,7 @@ module Cequel
       extend Forwardable
 
       def_delegators :@model, :loaded?, :updater, :deleter
+      def_delegators :__getobj__, :clone, :dup
 
       attr_reader :column_name
 
@@ -50,7 +51,9 @@ module Cequel
       private
 
       def to_modify(&block)
-        if loaded? then block.()
+        if loaded?
+          @model.__send__("#{@column_name}_will_change!")
+          block.()
         else modifications << block
         end
         self
@@ -175,6 +178,7 @@ module Cequel
         updater.set_add(column_name, object)
         to_modify { super }
       end
+      alias_method :<<, :add
 
       def clear
         deleter.delete_columns(column_name)

--- a/lib/cequel/model/dirty.rb
+++ b/lib/cequel/model/dirty.rb
@@ -1,0 +1,62 @@
+module Cequel
+
+  module Model
+
+    module Dirty
+
+      extend ActiveSupport::Concern
+
+      included { include ActiveModel::Dirty }
+
+      module ClassMethods
+
+        def key(name, *)
+          define_attribute_method(name)
+          super
+        end
+
+        def column(name, *)
+          define_attribute_method(name)
+          super
+        end
+
+        def set(name, *)
+          define_attribute_method(name)
+          super
+        end
+
+        def list(name, *)
+          define_attribute_method(name)
+          super
+        end
+
+        def map(name, *)
+          define_attribute_method(name)
+          super
+        end
+
+      end
+
+      def save(options = {})
+        super.tap do |success|
+          if success
+            @previously_changed = changes
+            @changed_attributes.clear
+          end
+        end
+      end
+
+      private
+
+      def write_attribute(name, value)
+        if loaded? && value != read_attribute(name)
+          __send__("#{name}_will_change!")
+        end
+        super
+      end
+
+    end
+
+  end
+
+end

--- a/spec/examples/model/dirty_spec.rb
+++ b/spec/examples/model/dirty_spec.rb
@@ -1,0 +1,68 @@
+require File.expand_path('../spec_helper', __FILE__)
+
+describe Cequel::Model::Dirty do
+  model :Post do
+    key :permalink, :text
+    column :title, :text
+    set :categories, :text
+  end
+
+  context 'loaded model' do
+    let(:post) do
+      Post.create!(
+        permalink: 'cequel',
+        title: 'Cequel',
+        categories: Set['Libraries']
+      )
+    end
+
+    it 'should not have changed attributes by default' do
+      post.changed_attributes.should be_empty
+    end
+
+    it 'should have changed attributes if attributes change' do
+      post.title = 'Cequel ORM'
+      post.changed_attributes.
+        should == {:title => 'Cequel'}.with_indifferent_access
+    end
+
+    it 'should not have changed attributes if attribute set to the same thing' do
+      post.title = 'Cequel'
+      post.changed_attributes.should be_empty
+    end
+
+    it 'should support *_changed? method' do
+      post.title = 'Cequel ORM'
+      post.title_changed?.should be_true
+    end
+
+    it 'should not have changed attributes after save' do
+      post.title = 'Cequel ORM'
+      post.save
+      post.changed_attributes.should be_empty
+    end
+
+    it 'should have previous changes after save' do
+      post.title = 'Cequel ORM'
+      post.save
+      post.previous_changes.
+        should == { :title => ['Cequel', 'Cequel ORM'] }.with_indifferent_access
+    end
+
+    it 'should detect changes to collections' do
+      post.categories << 'Gems'
+      post.changes.should ==
+        {categories: [Set['Libraries'], Set['Libraries', 'Gems']]}.
+        with_indifferent_access
+    end
+  end
+
+  context 'unloaded model' do
+    let(:post) { Post['cequel'] }
+
+    it 'should not track changes' do
+      post.title = 'Cequel'
+      post.changes.should be_empty
+    end
+  end
+end


### PR DESCRIPTION
- [x] Implement `#attributes=`, `::create`, and `#update_attributes`
- [x] Mass-assignment protection in Rails 3 and secure parameters in Rails 4
- [x] Callbacks
- [x] Validations
- [x] Dirty attributes
- [x] Serializers
- [x] Names
