### PR TITLE
Full support for legacy CQL2 tables

### DIFF
--- a/lib/cequel/record/schema.rb
+++ b/lib/cequel/record/schema.rb
@@ -16,7 +16,7 @@ module Cequel
         extend Forwardable
 
         def_delegators :table_schema, :key_columns, :key_column_names,
-          :partition_key_columns, :clustering_columns
+          :partition_key_columns, :clustering_columns, :compact_storage?
         def_delegator :table_schema, :column, :reflect_on_column
 
         def synchronize_schema
@@ -61,6 +61,10 @@ module Cequel
 
         def table_property(name, value)
           table_schema.add_property(name, value)
+        end
+
+        def compact_storage
+          table_schema.compact_storage = true
         end
 
       end

--- a/lib/cequel/schema/table_updater.rb
+++ b/lib/cequel/schema/table_updater.rb
@@ -41,7 +41,7 @@ module Cequel
       end
 
       def rename_column(old_name, new_name)
-        alter_table("RENAME #{old_name} TO #{new_name}")
+        alter_table(%(RENAME "#{old_name}" TO "#{new_name}"))
       end
 
       def change_properties(options)

--- a/spec/examples/record/schema_spec.rb
+++ b/spec/examples/record/schema_spec.rb
@@ -1,45 +1,88 @@
 require File.expand_path('../spec_helper', __FILE__)
 
 describe Cequel::Record::Schema do
-  after { cequel.schema.drop_table(:posts) }
-  subject { cequel.schema.read_table(:posts) }
+  context 'CQL3 table' do
+    after { cequel.schema.drop_table(:posts) }
+    subject { cequel.schema.read_table(:posts) }
 
-  let(:model) do
-    Class.new do
-      include Cequel::Record
-      self.table_name = 'posts'
+    let(:model) do
+      Class.new do
+        include Cequel::Record
+        self.table_name = 'posts'
 
-      key :permalink, :text
-      column :title, :text
-      list :categories, :text
-      set :tags, :text
-      map :trackbacks, :timestamp, :text
-      table_property :comment, 'Blog Posts'
-    end
-  end
-
-  context 'new model with simple primary key' do
-    before { model.synchronize_schema }
-
-    its(:partition_key_columns) { should == [Cequel::Schema::Column.new(:permalink, :text)] }
-    its(:data_columns) { should include(Cequel::Schema::Column.new(:title, :text)) }
-    its(:data_columns) { should include(Cequel::Schema::List.new(:categories, :text)) }
-    its(:data_columns) { should include(Cequel::Schema::Set.new(:tags, :text)) }
-    its(:data_columns) { should include(Cequel::Schema::Map.new(:trackbacks, :timestamp, :text)) }
-    specify { subject.property(:comment).should == 'Blog Posts' }
-  end
-
-  context 'existing model with additional attribute' do
-    before do
-      cequel.schema.create_table :posts do
         key :permalink, :text
         column :title, :text
         list :categories, :text
         set :tags, :text
+        map :trackbacks, :timestamp, :text
+        table_property :comment, 'Blog Posts'
       end
-      model.synchronize_schema
     end
 
-    its(:data_columns) { should include(Cequel::Schema::Map.new(:trackbacks, :timestamp, :text)) }
+    context 'new model with simple primary key' do
+      before { model.synchronize_schema }
+
+      its(:partition_key_columns) { should == [Cequel::Schema::Column.new(:permalink, :text)] }
+      its(:data_columns) { should include(Cequel::Schema::Column.new(:title, :text)) }
+      its(:data_columns) { should include(Cequel::Schema::List.new(:categories, :text)) }
+      its(:data_columns) { should include(Cequel::Schema::Set.new(:tags, :text)) }
+      its(:data_columns) { should include(Cequel::Schema::Map.new(:trackbacks, :timestamp, :text)) }
+      specify { subject.property(:comment).should == 'Blog Posts' }
+    end
+
+    context 'existing model with additional attribute' do
+      before do
+        cequel.schema.create_table :posts do
+          key :permalink, :text
+          column :title, :text
+          list :categories, :text
+          set :tags, :text
+        end
+        model.synchronize_schema
+      end
+
+      its(:data_columns) { should include(Cequel::Schema::Map.new(:trackbacks, :timestamp, :text)) }
+    end
+  end
+
+  context 'wide-row legacy table' do
+    let(:legacy_model) do
+      Class.new do
+        include Cequel::Record
+        self.table_name = 'legacy_posts'
+
+        key :blog_subdomain, :text
+        key :id, :uuid
+        column :data, :text
+
+        compact_storage
+      end
+    end
+    after { cequel.schema.drop_table(:legacy_posts) }
+    subject { cequel.schema.read_table(:legacy_posts) }
+
+    context 'new model' do
+      before { legacy_model.synchronize_schema }
+
+      its(:partition_key_columns) { should == [Cequel::Schema::Column.new(:blog_subdomain, :text)] }
+      its(:clustering_columns) { should == [Cequel::Schema::Column.new(:id, :uuid)] }
+      it { should be_compact_storage }
+      its(:data_columns) { should == [Cequel::Schema::Column.new(:data, :text)] }
+    end
+
+    context 'existing model' do
+      before do
+        legacy_connection.execute(<<-CQL2)
+          CREATE COLUMNFAMILY legacy_posts (blog_subdomain text PRIMARY KEY)
+          WITH comparator=uuid AND default_validation=text
+        CQL2
+        legacy_model.synchronize_schema
+      end
+
+      its(:partition_key_columns) { should == [Cequel::Schema::Column.new(:blog_subdomain, :text)] }
+      its(:clustering_columns) { should == [Cequel::Schema::Column.new(:id, :uuid)] }
+      it { should be_compact_storage }
+      its(:data_columns) { should == [Cequel::Schema::Column.new(:data, :text)] }
+    end
   end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -68,8 +68,20 @@ module Cequel
         ENV['CEQUEL_TEST_KEYSPACE'] || 'cequel_test'
       end
 
+      def self.legacy_connection
+        @legacy_connection ||= CassandraCQL::Database.new(
+          Cequel::SpecSupport::Helpers.host,
+          :keyspace => Cequel::SpecSupport::Helpers.keyspace_name,
+          :cql_version => '2.0.0'
+        )
+      end
+
       def cequel
         Helpers.cequel
+      end
+
+      def legacy_connection
+        Helpers.legacy_connection
       end
 
       def max_statements!(number)


### PR DESCRIPTION
- Correctly read schema for legacy tables
- Correctly rename default column names to defined column names when
  synchronizing
- Expose `compact_storage` directive in Cequel::Record
