### PR TITLE
Fixes for legacy schema support

### DIFF
--- a/lib/cequel/schema/table_reader.rb
+++ b/lib/cequel/schema/table_reader.rb
@@ -57,7 +57,7 @@ module Cequel
         unless comparators
           table.compact_storage = true
           return unless column_data.empty?
-          column_aliases << nil if column_aliases.empty?
+          column_aliases << :column1 if column_aliases.empty?
           comparators = [table_data['comparator']]
         end
         column_aliases.zip(comparators) do |column_alias, type|
@@ -66,7 +66,7 @@ module Cequel
             clustering_order = :desc
           end
           table.add_clustering_column(
-            column_alias.try(:to_sym),
+            column_alias.to_sym,
             Type.lookup_internal(type),
             clustering_order
           )
@@ -76,7 +76,7 @@ module Cequel
       def read_data_columns
         if column_data.empty?
           table.add_data_column(
-            table_data['value_alias'],
+            (table_data['value_alias'] || :data).to_sym,
             Type.lookup_internal(table_data['default_validator']),
             false
           )

--- a/spec/examples/record/schema_spec.rb
+++ b/spec/examples/record/schema_spec.rb
@@ -83,6 +83,10 @@ describe Cequel::Record::Schema do
       its(:clustering_columns) { should == [Cequel::Schema::Column.new(:id, :uuid)] }
       it { should be_compact_storage }
       its(:data_columns) { should == [Cequel::Schema::Column.new(:data, :text)] }
+
+      it 'should be able to synchronize schema again' do
+        expect { legacy_model.synchronize_schema }.to_not raise_error
+      end
     end
   end
 end

--- a/spec/examples/schema/table_reader_spec.rb
+++ b/spec/examples/schema/table_reader_spec.rb
@@ -381,9 +381,9 @@ describe Cequel::Schema::TableReader do
     its(:partition_key_columns) { should ==
       [Cequel::Schema::PartitionKey.new(:blog_subdomain, :text)] }
     its(:clustering_columns) { should ==
-      [Cequel::Schema::ClusteringColumn.new(nil, :uuid)] }
+      [Cequel::Schema::ClusteringColumn.new(:column1, :uuid)] }
     its(:data_columns) { should ==
-      [Cequel::Schema::DataColumn.new(nil, :text)] }
+      [Cequel::Schema::DataColumn.new(:data, :text)] }
   end
 
 end


### PR DESCRIPTION
- Internally represent legacy clustering column as `:column1` and legacy data
  column as `:data`, to be consistent with CQL3 internal representation
- Cast `value_alias` to a symbol
