### PR TITLE
Clearing a pre-existing value in a Set

### DIFF
--- a/lib/cequel/record/persistence.rb
+++ b/lib/cequel/record/persistence.rb
@@ -135,13 +135,17 @@ module Cequel
         super
       end
 
-      def write_attribute(attribute, value)
+      def write_attribute(name, value)
+        column = self.class.reflect_on_column(name)
+        raise UnknownAttributeError, "unknown attribute: #{name}" unless column
+        value = column.cast(value) unless value.nil?
+
         super.tap do
           unless new_record?
             if value.nil?
-              deleter.delete_columns(attribute)
+              deleter.delete_columns(name)
             else
-              updater.set(attribute => value)
+              updater.set(name => value)
             end
           end
         end

--- a/lib/cequel/record/properties.rb
+++ b/lib/cequel/record/properties.rb
@@ -163,10 +163,7 @@ module Cequel
       end
 
       def write_attribute(name, value)
-        column = self.class.reflect_on_column(name)
-        raise UnknownAttributeError,
-          "unknown attribute: #{name}" unless column
-        @attributes[name] = value.nil? ? nil : column.cast(value)
+        @attributes[name] = value
       end
 
       private

--- a/spec/examples/record/list_spec.rb
+++ b/spec/examples/record/list_spec.rb
@@ -27,6 +27,20 @@ describe Cequel::Record::List do
     end
   end
 
+  context 'updating' do
+    it 'should overwrite value' do
+      post.tags = %w(three four)
+      post.save!
+      subject[:tags].should == %w(three four)
+    end
+
+    it 'should cast collection before overwriting' do
+      post.tags = Set['three', 'four']
+      post.save!
+      subject[:tags].should == %w(three four)
+    end
+  end
+
   describe '#<<' do
     it 'should add new items' do
       post.tags << 'three' << 'four'

--- a/spec/examples/record/map_spec.rb
+++ b/spec/examples/record/map_spec.rb
@@ -27,6 +27,20 @@ describe Cequel::Record::Map do
     end
   end
 
+  context 'updating' do
+    it 'should overwrite value' do
+      post.likes = {'charlotte' => 3, 'dave' => 4}
+      post.save!
+      subject[:likes].should == {'charlotte' => 3, 'dave' => 4}
+    end
+
+    it 'should cast collection before overwriting' do
+      post.likes = [['charlotte', 3], ['dave', 4]]
+      post.save!
+      subject[:likes].should == {'charlotte' => 3, 'dave' => 4}
+    end
+  end
+
   describe 'atomic modification' do
     before { scope.map_update(:likes, 'charles' => 3) }
 

--- a/spec/examples/record/set_spec.rb
+++ b/spec/examples/record/set_spec.rb
@@ -27,6 +27,20 @@ describe Cequel::Record::Set do
     end
   end
 
+  context 'updating' do
+    it 'should overwrite value' do
+      post.tags = Set['three', 'four']
+      post.save!
+      subject[:tags].should == Set['three', 'four']
+    end
+
+    it 'should cast collection before overwriting' do
+      post.tags = %w(three four)
+      post.save!
+      subject[:tags].should == Set['three', 'four']
+    end
+  end
+
   describe 'atomic modification' do
     before { scope.set_add(:tags, 'three') }
 


### PR DESCRIPTION
To repro:
1. Create a table with one of its columns being a set.
2. Through the plugin, create a new instance and assign the set some value, then save.
3. Now, try to set the set value to something completely new (e.g., don't just append) and re-save it.

You should get an error like "CassandraCQL::Error::InvalidRequestException: Invalid list literal for labels of type set<text>". It looks like the problem is that the UPDATE command is issued with square brackets instead of curly. For example, it tries 

```
UPDATE google_mail_message_label_history_data SET labels = [] WHERE service_id = 234 AND gm_msg_id = 'abc'
```

 when CQL wants 

```
UPDATE google_mail_message_label_history_data SET labels = {} WHERE service_id = 234 AND gm_msg_id = 'abc'
```
## A bit of a sample repro:

```
datum = GoogleMailMessageLabelHistoryDatum.new(:service_id => service.id, :gm_msg_id => gm_msgid)
datum.labels = ["label1"]
datum.save!

datum.labels = ["clearit"]
datum.save!
```

As a sidenote, this does work if on the second declaration you declare the new label as a Set, 

```
datum.labels = Set['clearit']
```
