### PR TITLE
Upgrade the connection_pool dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       activemodel
       activesupport (>= 3.1)
       cassandra-cql (~> 1.2)
-      connection_pool (~> 0.9.2)
+      connection_pool (~> 1.1)
       i18n
 
 GEM
@@ -36,7 +36,7 @@ GEM
       thrift_client (>= 0.7.1, < 0.9)
     coderay (1.0.9)
     columnize (0.3.6)
-    connection_pool (0.9.3)
+    connection_pool (1.1.0)
     debugger (1.6.1)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
@@ -100,7 +100,7 @@ GEM
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.3)
     ruby-hmac (0.4.0)
-    simple_uuid (0.3.0)
+    simple_uuid (0.4.0)
     slop (3.4.6)
     spoon (0.0.4)
       ffi

--- a/cequel.gemspec
+++ b/cequel.gemspec
@@ -23,7 +23,7 @@ DESC
   s.add_runtime_dependency 'activesupport', '>= 3.1'
   s.add_runtime_dependency 'activemodel'
   s.add_runtime_dependency 'cassandra-cql', '~> 1.2'
-  s.add_runtime_dependency 'connection_pool', '~> 0.9.2'
+  s.add_runtime_dependency 'connection_pool', '~> 1.1'
   s.add_runtime_dependency 'i18n'
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'rspec', '~> 2.0'


### PR DESCRIPTION
connection_pool 1.0.0 is out now and the 0.9.2 dependency conflicts with any other libs using 1.0.0, such as Sidekiq.  I think they're largely API compatible, so you should still be able to work with 0.9.2 if you just loosen the dependency instead.
