### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Version](https://badge.fury.io/rb/cequel.png)](http://badge.fury.io/rb/cequel)
 Status](https://gemnasium.com/cequel/cequel.png)](https://gemnasium.com/cequel/cequel)
 [![Code
 Climate](https://codeclimate.com/github/cequel/cequel.png)](https://codeclimate.com/github/cequel/cequel)
+[![Inline docs](http://inch-pages.github.io/github/cequel/cequel.png)](http://inch-pages.github.io/github/cequel/cequel)
 
 `Cequel::Record` is an ActiveRecord-like domain model layer that exposes
 the robust data modeling capabilities of CQL3, including parent-child


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/cequel/cequel.png)](http://inch-pages.github.io/github/cequel/cequel)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. The status page for Cequel is http://inch-pages.github.io/github/cequel/cequel/

Inch Pages is still in it's infancy, but already used by projects like [Guard](https://github.com/guard/guard), [Pry](https://github.com/pry/pry), and [Libnotify](https://github.com/splattael/libnotify).

What do you think?
