### PR TITLE
Problem loading in Rails 3.2

### DIFF
--- a/lib/cequel/record/railtie.rb
+++ b/lib/cequel/record/railtie.rb
@@ -1,4 +1,6 @@
 # -*- encoding : utf-8 -*-
+require 'i18n/core_ext/hash'
+
 module Cequel
   module Record
     # @private


### PR DESCRIPTION
The docs indicate that the library should work in Rails 3.2, but unfortunately the rail tie uses a method that wasn't defined until Rails 4+.  `deep_symbolize_keys` doesn't existing in the Rails 3.2 ActiveSupport implementation. However,  it does exist in the `i18n` gem that Rails 3.2 relies on. I've worked around this for now by expliciitly doing `require 'i18n/core_ext/hash'` in my config/application.rb before initialization is able to begin.
