### PR TITLE
Fix `Cequel::Record#invalid?`

### DIFF
--- a/lib/cequel/record/validations.rb
+++ b/lib/cequel/record/validations.rb
@@ -83,8 +83,8 @@ module Cequel
 
       private
 
-      def valid_with_callbacks?
-        run_callbacks(:validation) { valid_without_callbacks? }
+      def valid_with_callbacks?(context=nil)
+        run_callbacks(:validation) { valid_without_callbacks? context }
       end
     end
   end

--- a/spec/examples/record/validations_spec.rb
+++ b/spec/examples/record/validations_spec.rb
@@ -37,6 +37,16 @@ describe Cequel::Record::Validations do
     end
   end
 
+  describe '#invalid?' do
+    it 'should be true if model is not valid' do
+      invalid_post.should be_invalid
+    end
+
+    it 'should be false if model is valid' do
+      valid_post.should_not be_invalid
+    end
+  end
+
   describe '#save' do
     it 'should return false and not persist model if invalid' do
       invalid_post.save.should be_false


### PR DESCRIPTION
Previously failed due to `#valid_with_callbacks?` not accepting the `context` argument.
