### PR TITLE
Error in include NewRelicInstrumentation

### DIFF
--- a/lib/cequel/metal/new_relic_instrumentation.rb
+++ b/lib/cequel/metal/new_relic_instrumentation.rb
@@ -24,4 +24,6 @@ module Cequel
   end
 end
 
-Cequel::Metal::Keyspace.module_eval { include NewRelicInstrumentation }
+Cequel::Metal::Keyspace.module_eval do
+  include Cequel::Metal::NewRelicInstrumentation
+end


### PR DESCRIPTION
cequel-1.1.0/lib/cequel/metal/new_relic_instrumentation.rb:27:in `block in <top (required)>': uninitialized constant NewRelicInstrumentation (NameError)

cequel 1.1.0
rails 3.2.17
cql-rb 1.2.1

I just changed 
Cequel::Metal::Keyspace.module_eval { include NewRelicInstrumentation }
to 
Cequel::Metal::Keyspace.module_eval { include Cequel::Metal::NewRelicInstrumentation }

Also i got error in rails g cequel:configuration
Specifying a hostname as host:port is deprecated. Specify only the host IP or hostname in :hosts, and specify a port for all nodes using the :port option.
Created cequel.yml manually with 
development:
  hosts: 
    - 127.0.0.1
