### PR TITLE
Support for native CQL protocol?

### DIFF
--- a/templates/config/cequel.yml
+++ b/templates/config/cequel.yml
@@ -1,19 +1,18 @@
 <% app_name = Cequel::Record::Railtie.app_name -%>
 development:
-  host: '127.0.0.1:9042'
+  host: '127.0.0.1'
+  port: 9042
   keyspace: <%= app_name %>_development
 
 test:
-  host: '127.0.0.1:9042'
+  host: '127.0.0.1'
+  port: 9042
   keyspace: <%= app_name %>_test
 
 production:
   hosts:
-    - 'cass1.<%= app_name %>.biz:9042'
-    - 'cass2.<%= app_name %>.biz:9042'
-    - 'cass3.<%= app_name %>.biz:9042'
+    - 'cass1.<%= app_name %>.biz'
+    - 'cass2.<%= app_name %>.biz'
+    - 'cass3.<%= app_name %>.biz'
+  port: 9042
   keyspace: <%= app_name %>_production
-  thrift:
-    retries: 10
-    timeout: 15
-    connect_timeout: 15


### PR DESCRIPTION
I guess this one is more of a question and likely requires a change to cassandra-cql.  But the generated cequel.yml references port 9042, which is the native CQL transport.  It also has thrift configuration options for production.  I'm new to Cassandra 1.2, so my understanding may very well be flawed, but I thought the point of the native CQL transport was to avoid having to use Thrift at all.  But I'm clearly seeing Thrift being used and the connections are failing over port 9042, while working over 9160 (my Cassandra config has both enabled).

Am I just doing something wrong? Or is Thrift always used?
