### PR TITLE
Deleted app_generators.orm setting from cequel's railtie

### DIFF
--- a/lib/cequel/record/railtie.rb
+++ b/lib/cequel/record/railtie.rb
@@ -7,7 +7,6 @@ module Cequel
     # @since 0.1.0
     class Railtie < Rails::Railtie
       config.cequel = Record
-      config.app_generators.orm :cequel
 
       def self.app_name
         Rails.application.railtie_name.sub(/_application$/, '')


### PR DESCRIPTION
Hi,
I want to pick main ORM library for generator.
app_generators.orm should be configured at `config/application.rb'.

Thank you for your great job!
