### PR TITLE
Add support for namespaced models

### DIFF
--- a/lib/cequel/record/schema.rb
+++ b/lib/cequel/record/schema.rb
@@ -20,7 +20,7 @@ module Cequel
 
       included do
         class_attribute :table_name, instance_writer: false
-        self.table_name = name.tableize.to_sym unless name.nil?
+        self.table_name = name.tableize.gsub('/', '__').to_sym unless name.nil?
       end
 
       #

--- a/lib/cequel/record/tasks.rb
+++ b/lib/cequel/record/tasks.rb
@@ -19,6 +19,7 @@ namespace :cequel do
   task :migrate => :environment do
     watch_stack = ActiveSupport::Dependencies::WatchStack.new
 
+    path_length = Rails.root.join('app', 'models').to_s.size
     Dir.glob(Rails.root.join('app', 'models', '**', '*.rb')).each do |file|
       watch_stack.watch_namespaces([Object])
 
@@ -26,7 +27,8 @@ namespace :cequel do
 
       new_constants = watch_stack.new_constants
       if new_constants.empty?
-        new_constants << File.basename(file, '.rb').classify
+        base_name = file[path_length...-3]
+        new_constants << base_name.classify
       end
 
       new_constants.each do |class_name|


### PR DESCRIPTION
This PR adds support for models inside a module.

e.g.

```
module Foo
  class Bar
    include Cequel::Record

    belongs_to :moo, class_name: 'Foo::Moo'
  end
end
```

This will create a column family named:  `foo__bars`.

I've used a double underscore as a separator to avoid conflicts with models named `FooBar`.

To use `belongs_to` and `has_many` you'll have to specify the `class_name`.
