### PR TITLE
Fix intermittent load failures of activesupport 4.0.x

### DIFF
--- a/lib/cequel.rb
+++ b/lib/cequel.rb
@@ -2,6 +2,7 @@
 require 'delegate'
 
 require 'active_support'
+require 'active_support/deprecation'
 require 'active_support/core_ext'
 require 'cql'
 


### PR DESCRIPTION
Explicitly requiring AS deprecation before AS core_ext seems to "fix" the problem.
