### PR TITLE
Add STATIC column support

### DIFF
--- a/lib/cequel/record/schema.rb
+++ b/lib/cequel/record/schema.rb
@@ -113,7 +113,7 @@ module Cequel
 
         def column(name, type, options = {})
           super
-          table_schema.add_data_column(name, type, options[:index])
+          table_schema.add_data_column(name, type, options)
         end
 
         def list(name, type, options = {})

--- a/lib/cequel/schema/column.rb
+++ b/lib/cequel/schema/column.rb
@@ -80,6 +80,13 @@ module Cequel
       end
 
       #
+      # @return [Boolean] true if this column is static
+      #
+      def static?
+        false
+      end
+
+      #
       # @param value the value to cast
       # @return the value cast to the appropriate type for this column
       #
@@ -181,10 +188,12 @@ module Cequel
       #
       # @param (see Column#initialize)
       # @param index_name [Symbol] name this column's secondary index
+      # @option options [Boolean] :static (false) whether this column is static
       #
-      def initialize(name, type, index_name = nil)
+      def initialize(name, type, index_name = nil, options = {})
         super(name, type)
         @index_name = index_name
+        @static = !!options[:static]
       end
 
       #
@@ -192,6 +201,21 @@ module Cequel
       #
       def indexed?
         !!@index_name
+      end
+
+      #
+      # @return [Boolean] true if this column is static
+      #
+      def static?
+        @static
+      end
+
+      def to_cql
+        if static?
+          "#{super} STATIC"
+        else
+          super
+        end
       end
     end
 

--- a/lib/cequel/schema/migration_validator.rb
+++ b/lib/cequel/schema/migration_validator.rb
@@ -99,6 +99,7 @@ module Cequel
           if old_column && new_column
             assert_valid_type_transition!(old_column, new_column)
             assert_same_column_structure!(old_column, new_column)
+            assert_same_static_flag!(old_column, new_column)
           end
         end
       end
@@ -122,6 +123,16 @@ module Cequel
                "Can't change #{old_column.name} from " \
                "#{old_column.class.name.demodulize} to " \
                "#{new_column.class.name.demodulize}"
+        end
+      end
+
+      def assert_same_static_flag!(old_column, new_column)
+        if old_column.static? != new_column.static?
+          if old_column.static?
+            fail InvalidSchemaMigration, "Can't remove STATIC flag from #{old_column.name}"
+          else
+            fail InvalidSchemaMigration, "Can't add STATIC flag to existing column #{old_column.name}"
+          end
         end
       end
     end

--- a/lib/cequel/schema/table.rb
+++ b/lib/cequel/schema/table.rb
@@ -109,7 +109,7 @@ module Cequel
         options = {index: options} unless options.is_a?(Hash)
         index_name = options[:index]
         index_name = :"#{@name}_#{name}_idx" if index_name == true
-        DataColumn.new(name, type(type), index_name)
+        DataColumn.new(name, type(type), index_name, static: options[:static])
           .tap { |column| @data_columns << add_column(column) }
       end
 

--- a/lib/cequel/schema/table_reader.rb
+++ b/lib/cequel/schema/table_reader.rb
@@ -123,7 +123,8 @@ module Cequel
               table.add_data_column(
                 result['column_name'].to_sym,
                 Type.lookup_internal(result['validator']),
-                result['index_name'].try(:to_sym)
+                index: result['index_name'].try(:to_sym),
+                static: result['type'] == 'static'
               )
             end
           end
@@ -171,7 +172,7 @@ module Cequel
               WHERE keyspace_name = ? AND columnfamily_name = ?
             CQL
             column_query.map(&:to_hash).select do |column|
-              !column.key?('type') || column['type'] == 'regular'
+              !column.key?('type') || %w[regular static].include?(column['type'])
             end
           end
       end

--- a/spec/examples/schema/table_synchronizer_spec.rb
+++ b/spec/examples/schema/table_synchronizer_spec.rb
@@ -10,6 +10,7 @@ describe Cequel::Schema::TableSynchronizer do
       cequel.schema.sync_table :posts do
         key :blog_subdomain, :text
         key :permalink, :text
+        column :blog_title, :text, static: true
         column :title, :text
         column :body, :text
         column :created_at, :timestamp
@@ -22,6 +23,8 @@ describe Cequel::Schema::TableSynchronizer do
 
     it 'should create table' do
       table.column(:title).type.should == Cequel::Type[:text] #etc.
+      table.column(:blog_title).type.should == Cequel::Type[:text]
+      table.column(:blog_title).static?.should == true
     end
   end
 
@@ -30,6 +33,7 @@ describe Cequel::Schema::TableSynchronizer do
       cequel.schema.create_table :posts do
         key :blog_subdomain, :text
         key :permalink, :text
+        column :blog_title, :text, static: true
         column :title, :ascii, :index => true
         column :body, :ascii
         column :created_at, :timestamp
@@ -46,6 +50,8 @@ describe Cequel::Schema::TableSynchronizer do
         cequel.schema.sync_table :posts do
           key :blog_subdomain, :text
           key :post_permalink, :text
+          column :blog_title, :text, static: true
+          column :blog_description, :text, static: true
           column :title, :ascii
           column :body, :text
           column :primary_author_id, :uuid, :index => true
@@ -63,6 +69,8 @@ describe Cequel::Schema::TableSynchronizer do
 
       it 'should add new columns' do
         table.column(:published_at).type.should == Cequel::Type[:timestamp]
+        table.column(:blog_description).type.should == Cequel::Type[:text]
+        table.column(:blog_description).static?.should == true
       end
 
       it 'should add new collections' do
@@ -182,6 +190,35 @@ describe Cequel::Schema::TableSynchronizer do
           cequel.schema.sync_table :posts do
             key :blog_subdomain, :text
             key :permalink, :text, :desc
+            column :title, :ascii, :index => true
+            column :body, :ascii
+            column :created_at, :timestamp
+            set :author_names, :text
+            with :comment, 'Test Table'
+          end
+        }.to raise_error(Cequel::InvalidSchemaMigration)
+      end
+
+      it 'should not allow changing a column to static' do
+        expect {
+          cequel.schema.sync_table :posts do
+            key :blog_subdomain, :text
+            key :permalink, :text
+            column :title, :ascii, :index => true
+            column :body, :ascii
+            column :created_at, :timestamp, static: true
+            set :author_names, :text
+            with :comment, 'Test Table'
+          end
+        }.to raise_error(Cequel::InvalidSchemaMigration)
+      end
+
+      it 'should not allow changing a column from static' do
+        expect {
+          cequel.schema.sync_table :posts do
+            key :blog_subdomain, :text
+            key :permalink, :text
+            column :blog_title, :text, static: false
             column :title, :ascii, :index => true
             column :body, :ascii
             column :created_at, :timestamp

--- a/spec/examples/schema/table_writer_spec.rb
+++ b/spec/examples/schema/table_writer_spec.rb
@@ -11,6 +11,17 @@ describe Cequel::Schema::TableWriter do
       cequel.schema.drop_table(:posts)
     end
 
+    describe 'with static column' do
+      it 'should create a static column' do
+        cequel.schema.create_table(:posts) do
+          key :blog_permalink, :ascii
+          key :id, :uuid, :desc
+          column :blog_title, :text, static: true
+        end
+        table.data_column(:blog_title).static?.should == true
+      end
+    end
+
     describe 'with simple skinny table' do
       before do
         cequel.schema.create_table(:posts) do


### PR DESCRIPTION
Allows you to have static columns when using a clustering key.

e.g.

    class Post
      include Cequel::Record

      key :blog_subdomain, :text
      key :id, :timeuuid, auto: true
      column :blog_title, :text, static: true
      column :title, :text
      column :body, :text
      column :created_at, :timestamp
    end

