### PR TITLE
Change file order at migration

### DIFF
--- a/lib/cequel/record/tasks.rb
+++ b/lib/cequel/record/tasks.rb
@@ -21,7 +21,7 @@ namespace :cequel do
 
     migration_table_names = Set[]
     models_dir_path = "#{Rails.root.join('app', 'models')}/"
-    Dir.glob(Rails.root.join('app', 'models', '**', '*.rb')).each do |file|
+    Dir.glob(Rails.root.join('app', 'models', '**', '*.rb')).sort.each do |file|
       watch_namespaces = ["Object"]
       model_file_name = file.sub(/^#{Regexp.escape(models_dir_path)}/, "")
       dirname = File.dirname(model_file_name)


### PR DESCRIPTION
Hi,

Dir.glob lists files:
1. app/models/user/item.rb
2. app/models/user.rb

This commit:
1. app/models/user.rb
2. app/models/user/item.rb

Why need change order?

Migrate using original code failed wit special case association model.
because `String#constantize` doesn't load `app/model/user.rb` when processing `app/models/user/item.rb` in this case.

app/models/user.rb

``` ruby
class User
  include Cequel::Record

  key :id, :text
  has_many :item, class_name: "User::Item"
end
```

app/models/user/item.rb

``` ruby
class User
  class Item
    include Cequel::Record

    belongs_to :user
    key :id, :text
  end
end
```

thank you.
