### PR TITLE
rake cequel:migrate should not scan files under the directory 'app/models/concerns'

### DIFF
--- a/lib/cequel/record/tasks.rb
+++ b/lib/cequel/record/tasks.rb
@@ -26,7 +26,6 @@ namespace :cequel do
       watch_namespaces = ["Object"]
       model_file_name = file.sub(/^#{Regexp.escape(models_dir_path)}/, "")
       dirname = File.dirname(model_file_name)
-      next if dirname == 'concerns' || File.dirname(dirname) == 'concerns'
       watch_namespaces << dirname.classify unless dirname == "."
       watch_stack.watch_namespaces(watch_namespaces)
       require_dependency(file)
@@ -39,7 +38,7 @@ namespace :cequel do
       new_constants.each do |class_name|
         begin
           clazz = class_name.constantize
-        rescue NameError # rubocop:disable HandleExceptions
+        rescue NameError, RuntimeError # rubocop:disable HandleExceptions
         else
           if clazz.ancestors.include?(Cequel::Record) &&
               !migration_table_names.include?(clazz.table_name.to_sym)


### PR DESCRIPTION
Hi. I think "rake cequel:migrate" should not scan files under the 'app/models/concerns' because files under it  don't have module name 'Concerns'.
