### PR TITLE
Finders don't automatically convert string uuid's into Cql::Uuid before execute

### DIFF
--- a/lib/cequel/record/record_set.rb
+++ b/lib/cequel/record/record_set.rb
@@ -727,7 +727,9 @@ module Cequel
         if value.is_a?(Range)
           self.in(value)
         else
-          scoped { |attributes| attributes[:scoped_key_values] << value }
+          scoped do |attributes|
+            attributes[:scoped_key_values] << cast_next_primary_key(value)
+          end
         end
       end
 
@@ -898,6 +900,14 @@ module Cequel
         return enum_for(:key_attributes_for_each_row) unless block_given?
         select(*key_column_names).find_each do |record|
           yield record.key_attributes
+        end
+      end
+
+      def cast_next_primary_key(value)
+        if value.is_a?(Array)
+          value.map { |element| next_unscoped_key_column.cast(element) }
+        else
+          next_unscoped_key_column.cast(value)
         end
       end
     end


### PR DESCRIPTION
Executing a finder like this:
State.find_by_dot_id_and_namespace_and_type_and_id('fef87e70-d405-11e3-9363-31301ac5f848', 'dev', 'object', 'alarm/test_state_id')

Gives me the error:
ql::QueryError: Invalid STRING constant (fef87e70-d405-11e3-9363-31301ac5f848) for dot_id of type uuid

dot_id is a uuid primary key colum and should have been automatically serialized.
