### PR TITLE
Set column TTL on create

### DIFF
--- a/lib/cequel/metal/data_set.rb
+++ b/lib/cequel/metal/data_set.rb
@@ -471,6 +471,7 @@ module Cequel
           data_set.writetime_columns.concat(columns.flatten)
         end
       end
+      alias_method :select_timestamp, :select_writetime
 
       #
       # Select specified columns from this data set, overriding chained scope.

--- a/lib/cequel/metal/row.rb
+++ b/lib/cequel/metal/row.rb
@@ -59,6 +59,7 @@ module Cequel
       def writetime(column)
         @writetimes[column]
       end
+      alias_method :timestamp, :writetime
 
       # @private
       def set_ttl(column, value)

--- a/lib/cequel/record/persistence.rb
+++ b/lib/cequel/record/persistence.rb
@@ -177,7 +177,7 @@ module Cequel
       # @see Validations#save!
       #
       def save(options = {})
-        options.assert_valid_keys(:consistency)
+        options.assert_valid_keys(:consistency, :ttl, :timestamp)
         if new_record? then create(options)
         else update(options)
         end
@@ -206,7 +206,7 @@ module Cequel
       # @return [Record] self
       #
       def destroy(options = {})
-        options.assert_valid_keys(:consistency)
+        options.assert_valid_keys(:consistency, :timestamp)
         assert_keys_present!
         metal_scope.delete(options)
         transient!


### PR DESCRIPTION
Is there any easy way to set the column TTL when using Model's create with a block?

I would expect something like this:

``` ruby
DailyStat.create(ttl: 30.days) do |daily_stat|
  daily_stat.datetime = Time.now
  daily_stat.value = 3
end
```

But so far, the only way I found to do it is through the insert method: 

``` ruby
DailyStat.table.insert({
  datetime: Time.now,
  value: 3
}, ttl: 30.days)
```
