### PR TITLE
Read default_consistency from cequel.yml

### DIFF
--- a/lib/cequel/metal/keyspace.rb
+++ b/lib/cequel/metal/keyspace.rb
@@ -123,6 +123,7 @@ module Cequel
         @max_retries  = extract_max_retries(configuration)
 
         @name = configuration[:keyspace]
+        @default_consistency = configuration[:default_consistency].try(:to_sym)
 
         # reset the connections
         clear_active_connections!


### PR DESCRIPTION
Try to read default consistency from configuration. If not supplied leave nil so it will behave as before.
