### PR TITLE
Add truncate function to record classes.

### DIFF
--- a/lib/cequel/record/persistence.rb
+++ b/lib/cequel/record/persistence.rb
@@ -62,6 +62,10 @@ module Cequel
           new_empty.hydrate(row)
         end
 
+        def truncate
+          connection.execute("TRUNCATE #{table_name}")
+        end
+
         # @private
         def_delegator 'Cequel::Record', :connection
       end


### PR DESCRIPTION
This is primarily for convenience. This makes it possible to do things like:

```
class MyClass
  include Cequel::Record
  # ... stuff ...
end

MyClass.truncate
```
