### PR TITLE
remove classify logic from migrate task to support plural class name

### DIFF
--- a/lib/cequel/record/tasks.rb
+++ b/lib/cequel/record/tasks.rb
@@ -26,13 +26,13 @@ namespace :cequel do
       watch_namespaces = ["Object"]
       model_file_name = file.sub(/^#{Regexp.escape(models_dir_path)}/, "")
       dirname = File.dirname(model_file_name)
-      watch_namespaces << dirname.classify unless dirname == "."
+      watch_namespaces << dirname.sub(/.*\./,'').camelize unless dirname == "."
       watch_stack.watch_namespaces(watch_namespaces)
       require_dependency(file)
 
       new_constants = watch_stack.new_constants
       if new_constants.empty?
-        new_constants << model_file_name.sub(/\.rb$/, "").classify
+        new_constants << model_file_name.sub(/\.rb$/, "").camelize
       end
 
       new_constants.each do |class_name|


### PR DESCRIPTION
Hi @outoftime, This is a PR to get support from migrate task to support plural class name.
Given a class like below

``` ruby
#user/followings.rb (file name)

class User::Followings
 include Cequel::Record
end
```

This class will not be passed to migrator to synchronize with database because current logic try to use rails `String#classify` method which automatically convert file name to singular form, as in:
https://github.com/cequel/cequel/blob/master/lib/cequel/record/tasks.rb#L29
https://github.com/cequel/cequel/blob/master/lib/cequel/record/tasks.rb#L35

May be this PR seems to be opinionated, but cassandra table is not like mysql table, which design to construct "an object". In many cases, cassandra table (column family) represent "a group of objects", which better to be represented as a pluralized class name.

An official datastax tutorial in [here](http://www.slideshare.net/DataStax/cassandra-community-webinar-back-to-basics-with-cql3) show some good examples as well, as how to model twitter system.

Thank you
