### PR TITLE
Allow config/cequel.yml to specify setting replication strategy and settings

### DIFF
--- a/lib/cequel/schema/keyspace.rb
+++ b/lib/cequel/schema/keyspace.rb
@@ -35,12 +35,24 @@ module Cequel
       #   http://cassandra.apache.org/doc/cql3/CQL.html#createKeyspaceStmt
       #   CQL3 CREATE KEYSPACE documentation
       #
+      # Uses the config/cequel.yml config file for defaults.
+      #   strategy_class: SimpleStrategy
+      #   strategy_options:
+      #     replication_factor: 2
+      #   or
+      #   strategy_class: NetworkTopologyStrategy
+      #   strategy_options:
+      #     DC1: 2
+      #     DC2: 1
+      #
       def create!(options = {})
         bare_connection =
           Metal::Keyspace.new(keyspace.configuration.except(:keyspace))
 
         options = options.symbolize_keys
-        options[:class] ||= 'SimpleStrategy'
+        strategy_options = keyspace.configuration[:strategy_options] || {}
+        options[:class] ||= keyspace.configuration[:strategy_class] || 'SimpleStrategy'
+        options.reverse_merge!(strategy_options)
         if options[:class] == 'SimpleStrategy'
           options[:replication_factor] ||= 1
         end

--- a/templates/config/cequel.yml
+++ b/templates/config/cequel.yml
@@ -4,6 +4,13 @@ development:
   port: 9042
   keyspace: <%= app_name %>_development
   max_retries: 3
+  strategy_class: SimpleStrategy
+  strategy_options:
+    replication_factor: 2
+#  strategy_class: NetworkTopologyStrategy
+#  strategy_options:
+#    DC1: 2
+#    DC2: 1
 
 test:
   host: '127.0.0.1'


### PR DESCRIPTION
The rake task does not provide a method to pass in options when creating the keyspace.

Based on the config file settings used in create_keyspace https://github.com/reachlocal/cequel-migrations-rails/blob/master/lib/cequel-migrations-rails/keyspace_manager.rb#L16.

This gets it working with configs we currently used, but I suppose that it might be better to have a strategy section of the config file, with :class and :options defined. But then I wonder if durable_writes should be configurable too.

I also know I'm beyond 80 chars on one of the lines, and I'm not sure how ||= with || is best handled.

I'm welcome to advice on how this should be improved.
