### PR TITLE
Demodulize model class name before transforming it to table name

### DIFF
--- a/lib/cequel/record/schema.rb
+++ b/lib/cequel/record/schema.rb
@@ -20,7 +20,7 @@ module Cequel
 
       included do
         class_attribute :table_name, instance_writer: false
-        self.table_name = name.tableize.to_sym unless name.nil?
+        self.table_name = name.demodulize.tableize.to_sym unless name.nil?
       end
 
       #


### PR DESCRIPTION
I found myself with a model defined inside a module and my migrations wouldn't work anymore.

That's because `name.tableize` will return `"module/class_name"` and thus generate an invalid table name for the schema.

This fix simply `demodulize` the class name before "tableizing" it, so that we don't end up with slashes in the table name.

It works for me and my tables, however I'm thinking: maybe it would be better not to demodulize and replace slashes with underscores instead, so that the module names become a prefix for the table name?  
I'm open to discussion ^^

As for testing this, well... I'm not sure it is satisfying enough that tests still pass after this change? I'd be glad to add specific tests but I'll happily take pointers on how/where to test it!
