### PR TITLE
Allow setting a key attribute to what it already is

### DIFF
--- a/lib/cequel/record/persistence.rb
+++ b/lib/cequel/record/persistence.rb
@@ -312,18 +312,22 @@ module Cequel
         fail UnknownAttributeError, "unknown attribute: #{name}" unless column
         value = column.cast(value) unless value.nil?
 
-        super.tap do
-          unless new_record?
-            if key_attributes.keys.include?(name)
-              fail ArgumentError,
-                   "Can't update key #{name} on persisted record"
-            end
+        if !new_record? && key_attributes.keys.include?(name)
+          if read_attribute(name) != value
+            fail ArgumentError,
+                 "Can't update key #{name} on persisted record"
+          end
+        else
+          super.tap { stage_attribute_update(name, value) }
+        end
+      end
 
-            if value.nil?
-              deleter.delete_columns(name)
-            else
-              updater.set(name => value)
-            end
+      def stage_attribute_update(name, value)
+        unless new_record?
+          if value.nil?
+            deleter.delete_columns(name)
+          else
+            updater.set(name => value)
           end
         end
       end

--- a/spec/examples/record/persistence_spec.rb
+++ b/spec/examples/record/persistence_spec.rb
@@ -103,6 +103,13 @@ describe Cequel::Record::Persistence do
           }.to raise_error(ArgumentError)
         end
 
+        it 'should allow setting a key value to the same thing it already is' do
+          expect {
+            blog.subdomain = 'cequel'
+            blog.save
+          }.to_not raise_error
+        end
+
         it 'should save with specified consistency' do
           expect_query_with_consistency(/UPDATE/, :one) do
             blog.name = 'Cequel'


### PR DESCRIPTION
Generally, attempting to set the key attribute on a persisted record is a
no-go. However, if you're setting it to the same thing it already is, no harm
done; it's just a no-op.
