### PR TITLE
Added ability to 'upsert' record by calling update for all save actions

### DIFF
--- a/lib/cequel/record/persistence.rb
+++ b/lib/cequel/record/persistence.rb
@@ -192,6 +192,31 @@ module Cequel
       end
 
       #
+      # Upsert the record into the database. In cases where the keys are known
+      # and `UPDATE` should be issued to do an upsert to prevent the need to
+      # do a read, then write. This works especially well when adding data to
+      # collection data types. This should never be used in situations where
+      # keys are auto generated or not known.
+      #
+      # @param options [Options] options that will be passed to save
+      # @option options [Boolean] :validate (true) whether to run validations
+      #   before saving
+      # @option options [Symbol] :consistency (:quorum) what consistency with
+      #   which to persist the changes
+      # @option options [Integer] :ttl time-to-live of the updated rows in
+      #   seconds
+      # @option options [Time] :timestamp the writetime to use for the column
+      #   updates
+      # @return [Boolean] true if record saved successfully, false if invalid
+      #
+      # @see Validations#save!
+      #
+      def upsert(options={})
+        @new_record = false # force save to run as an update
+        save(options)
+      end
+
+      #
       # Set attributes and save the record
       #
       # @param attributes [Hash] hash of attributes to update

--- a/spec/examples/record/persistence_spec.rb
+++ b/spec/examples/record/persistence_spec.rb
@@ -330,6 +330,24 @@ describe Cequel::Record::Persistence do
       end
     end
 
+    describe '#upsert' do
+      context 'new record' do
+        it 'should raise an error if the key is not provided' do
+          expect {
+            Blog.new.upsert
+          }.to raise_error
+        end
+
+        it 'should update new records' do
+          expect_query_with_consistency(/UPDATE/, :one) {
+            blog = Blog.new
+            blog.subdomain = 'subdomain'
+            blog.upsert(consistency: :one)
+          }
+        end
+      end
+    end
+
     describe '#destroy' do
       before { post.destroy }
 


### PR DESCRIPTION
I did this to take advantage of the built in upsert feature in cassandra to
update or create records when an update command is issued with known keys.
This is especially helpful with interacting with collections and prevents the
need to do a read then write.