### PR TITLE
Make Rake tasks work without Rails

### DIFF
--- a/lib/cequel/record/tasks.rb
+++ b/lib/cequel/record/tasks.rb
@@ -1,4 +1,7 @@
 # -*- encoding : utf-8 -*-
+task :environment do
+end
+
 namespace :cequel do
   namespace :keyspace do
     desc 'Initialize Cassandra keyspace'
@@ -20,8 +23,9 @@ namespace :cequel do
     watch_stack = ActiveSupport::Dependencies::WatchStack.new
 
     migration_table_names = Set[]
-    models_dir_path = "#{Rails.root.join('app', 'models')}/"
-    model_files = Dir.glob(Rails.root.join('app', 'models', '**', '*.rb'))
+    project_root = defined?(Rails) ? Rails.root : Dir.pwd
+    models_dir_path = "#{File.expand_path('app/models', project_root)}/"
+    model_files = Dir.glob(File.join(models_dir_path, '**', '*.rb'))
     model_files.sort.each do |file|
       watch_namespaces = ["Object"]
       model_file_name = file.sub(/^#{Regexp.escape(models_dir_path)}/, "")


### PR DESCRIPTION
- Define an empty `:environment` task (this won't override an existing one)
- Check if `Rails` constant is defined; if not, project root is working
  directory
