### PR TITLE
Fix recovery from connection error 

### DIFF
--- a/lib/cequel/metal/keyspace.rb
+++ b/lib/cequel/metal/keyspace.rb
@@ -209,6 +209,9 @@ module Cequel
         if defined? @client
           remove_instance_variable(:@client)
         end
+        if defined? @raw_client
+          remove_instance_variable(:@raw_client)
+        end
       end
 
       #

--- a/spec/examples/metal/keyspace_spec.rb
+++ b/spec/examples/metal/keyspace_spec.rb
@@ -97,8 +97,8 @@ describe Cequel::Metal::Keyspace do
 
     context "with a connection error" do
       it "reconnects to cassandra with a new client after first failed connection" do
-        allow(cequel.client).to receive(:execute_with_consistency)
-          .with(statement, [], nil)
+        allow(cequel.client).to receive(:execute)
+          .with(statement, cequel.default_consistency)
           .and_raise(Ione::Io::ConnectionError)
           .once
 


### PR DESCRIPTION
https://github.com/cequel/cequel/issues/173
- Stub the correct Cql method to throw an error (no such method
  client#execute_with_consistency).
- Delete both the client and the raw client, so both will be recreated
  on retry.
