### PR TITLE
Fix recovery from connection error

### DIFF
--- a/lib/cequel/metal/keyspace.rb
+++ b/lib/cequel/metal/keyspace.rb
@@ -23,6 +23,8 @@ module Cequel
       attr_reader :port
       # @return Integer maximum number of retries to reconnect to Cassandra
       attr_reader :max_retries
+      # @return Float delay between retries to reconnect to Cassandra
+      attr_reader :retry_delay
       # @return [Symbol] the default consistency for queries in this keyspace
       # @since 1.1.0
       attr_writer :default_consistency
@@ -121,6 +123,7 @@ module Cequel
         @hosts, @port = extract_hosts_and_port(configuration)
         @credentials  = extract_credentials(configuration)
         @max_retries  = extract_max_retries(configuration)
+        @retry_delay  = extract_retry_delay(configuration)
 
         @name = configuration[:keyspace]
         @default_consistency = configuration[:default_consistency].try(:to_sym)
@@ -171,16 +174,7 @@ module Cequel
       # @see #execute_with_consistency
       #
       def execute(statement, *bind_vars)
-        retries = max_retries
-
-        begin
-          execute_with_consistency(statement, bind_vars, default_consistency)
-        rescue Cql::NotConnectedError, Ione::Io::ConnectionError
-          clear_active_connections!
-          raise if retries < 0
-          retries -= 1
-          retry
-        end
+        execute_with_consistency(statement, bind_vars, default_consistency)
       end
 
       #
@@ -194,9 +188,19 @@ module Cequel
       # @since 1.1.0
       #
       def execute_with_consistency(statement, bind_vars, consistency)
+        retries = max_retries
+
         log('CQL', statement, *bind_vars) do
-          client.execute(sanitize(statement, bind_vars),
+          begin
+            client.execute(sanitize(statement, bind_vars),
                          consistency || default_consistency)
+          rescue Cql::NotConnectedError, Ione::Io::ConnectionError
+            clear_active_connections!
+            raise if retries == 0
+            retries -= 1
+            sleep(retry_delay)
+            retry
+          end
         end
       end
 
@@ -208,6 +212,9 @@ module Cequel
       def clear_active_connections!
         if defined? @client
           remove_instance_variable(:@client)
+        end
+        if defined? @raw_client
+          remove_instance_variable(:@raw_client)
         end
       end
 
@@ -292,6 +299,10 @@ module Cequel
 
       def extract_max_retries(configuration)
         configuration.fetch(:max_retries, 3)
+      end
+
+      def extract_retry_delay(configuration)
+        configuration.fetch(:retry_delay, 0.5)
       end
     end
   end

--- a/spec/examples/metal/keyspace_spec.rb
+++ b/spec/examples/metal/keyspace_spec.rb
@@ -97,8 +97,8 @@ describe Cequel::Metal::Keyspace do
 
     context "with a connection error" do
       it "reconnects to cassandra with a new client after first failed connection" do
-        allow(cequel.client).to receive(:execute_with_consistency)
-          .with(statement, [], nil)
+        allow(cequel.client).to receive(:execute)
+          .with(statement, cequel.default_consistency)
           .and_raise(Ione::Io::ConnectionError)
           .once
 

--- a/templates/config/cequel.yml
+++ b/templates/config/cequel.yml
@@ -4,12 +4,14 @@ development:
   port: 9042
   keyspace: <%= app_name %>_development
   max_retries: 3
+  retry_delay: 0.5
 
 test:
   host: '127.0.0.1'
   port: 9042
   keyspace: <%= app_name %>_test
   max_retries: 3
+  retry_delay: 0.5
 
 production:
   hosts:
@@ -21,3 +23,4 @@ production:
   username: 'myappuser'
   password: 'password1'
   max_retries: 3
+  retry_delay: 0.5


### PR DESCRIPTION
https://github.com/cequel/cequel/issues/173
- Stub the correct Cql method to throw an error (no such method
  client#execute_with_consistency).
- Delete both the client and the raw client, so both will be recreated
  on retry.
- Move retry logic to #execute_with_consistency.
- Add configurable delay to retry loop.
