### PR TITLE
Add optional support for new relic

### DIFF
--- a/lib/cequel/metal/new_relic_instrumentation.rb
+++ b/lib/cequel/metal/new_relic_instrumentation.rb
@@ -16,7 +16,7 @@ module Cequel
       included do
         include NewRelic::Agent::MethodTracer
 
-        add_method_tracer :execute,
+        add_method_tracer :execute_with_consistency,
                           'Database/Cassandra/#{args[0][/^[A-Z ]*[A-Z]/]' \
                           '.sub(/ FROM$/, \'\')}'
       end

--- a/templates/config/cequel.yml
+++ b/templates/config/cequel.yml
@@ -5,6 +5,7 @@ development:
   keyspace: <%= app_name %>_development
   max_retries: 3
   retry_delay: 0.5
+  newrelic: false
 
 test:
   host: '127.0.0.1'
@@ -12,6 +13,7 @@ test:
   keyspace: <%= app_name %>_test
   max_retries: 3
   retry_delay: 0.5
+  newrelic: false
 
 production:
   hosts:
@@ -24,3 +26,4 @@ production:
   password: 'password1'
   max_retries: 3
   retry_delay: 0.5
+  newrelic: true


### PR DESCRIPTION
On our current project we have run into an issue where:
- New Relic instrumentation wasn't working for us
- With a fix for New Relic Instrumentation it was too much and we wanted to turn off Cequel gem instrumentation and create our own.

This PR adds a change to the cequel.yml file to support a `newrelic_enabled: boolean` parameter and a check in the cequel/record/railtie.rb initialization for this new param.  If the param is false we completely bypass importing NewRelicInstumentation

To get instrumentation working we trace :execute_with_consistency

-Jeff Holland
