### PR TITLE
Don't interact with updater/deleter if new record

### DIFF
--- a/lib/cequel/record/persistence.rb
+++ b/lib/cequel/record/persistence.rb
@@ -292,10 +292,12 @@ module Cequel
       instrument :update, data: ->(rec) { {table_name: rec.table_name} }
 
       def updater
+        raise ArgumentError, "Can't get updater for new record" if new_record?
         @updater ||= Metal::Updater.new(metal_scope)
       end
 
       def deleter
+        raise ArgumentError, "Can't get deleter for new record" if new_record?
         @deleter ||= Metal::Deleter.new(metal_scope)
       end
 

--- a/spec/examples/record/list_spec.rb
+++ b/spec/examples/record/list_spec.rb
@@ -45,6 +45,15 @@ describe Cequel::Record::List do
   end
 
   describe '#<<' do
+    it 'should not re-apply after creation' do
+      post = Post.new(permalink: 'cequel')
+      post.tags << 'one'
+      post.save!
+      post.tags << 'two'
+      post.save!
+      expect(subject[:tags]).to eq(%w(one two))
+    end
+
     it 'should add new items' do
       post.tags << 'three' << 'four'
       post.save


### PR DESCRIPTION
In particular, discrete collection modifications were propagating their
changes to the owning record's `updater` or `deleter` even if it was a
new record. When new records are saved, their collection values are just
set wholesale; the `updater` and `deleter` aren't used at all. If you
then updated the same in-memory record, the `updater` would re-run the
same changes that had happened before record creation, resulting in
incorrect behavior for lists and maps.

Attempting to access the `updater` or `deleter` on a new record now
raises an error, and collections use a `to_update` block to only stage
changes for discrete persistence if the owning record is not a new
record.

Fixes #188
