### PR TITLE
skip dir concerns under app/models for rake cequel:migrate

### DIFF
--- a/lib/cequel/record/tasks.rb
+++ b/lib/cequel/record/tasks.rb
@@ -42,7 +42,7 @@ namespace :cequel do
       new_constants.each do |class_name|
         begin
           clazz = class_name.constantize
-        rescue NameError, RuntimeError # rubocop:disable HandleExceptions
+        rescue LoadError, NameError, RuntimeError # rubocop:disable HandleExceptions
         else
           if clazz.is_a?(Class)
             if clazz.ancestors.include?(Cequel::Record) &&

--- a/lib/cequel/record/tasks.rb
+++ b/lib/cequel/record/tasks.rb
@@ -26,6 +26,7 @@ namespace :cequel do
     project_root = defined?(Rails) ? Rails.root : Dir.pwd
     models_dir_path = "#{File.expand_path('app/models', project_root)}/"
     model_files = Dir.glob(File.join(models_dir_path, '**', '*.rb'))
+    model_files.reject! {|file| file =~ /^#{File.join(models_dir_path, 'concerns')}/}
     model_files.sort.each do |file|
       watch_namespaces = ["Object"]
       model_file_name = file.sub(/^#{Regexp.escape(models_dir_path)}/, "")

--- a/lib/cequel/record/tasks.rb
+++ b/lib/cequel/record/tasks.rb
@@ -26,7 +26,6 @@ namespace :cequel do
     project_root = defined?(Rails) ? Rails.root : Dir.pwd
     models_dir_path = "#{File.expand_path('app/models', project_root)}/"
     model_files = Dir.glob(File.join(models_dir_path, '**', '*.rb'))
-    model_files.reject! {|file| file =~ /^#{File.join(models_dir_path, 'concerns')}/}
     model_files.sort.each do |file|
       watch_namespaces = ["Object"]
       model_file_name = file.sub(/^#{Regexp.escape(models_dir_path)}/, "")


### PR DESCRIPTION
To avoid error as below:
LoadError: Unable to autoload constant Concerns::Dummy, expected .../test/app/models/concerns/dummy.rb to define it

cat dummy.rb
module Dummy
  extend ActiveSupport::Concern
  ...
end

Since rails autoloads app/models/concerns, files in the dir have no namespace Concerns.
http://guides.rubyonrails.org/constant_autoloading_and_reloading.html#autoload-paths