### PR TITLE
Fix cannot call original Forwardable#delegate issue.

### DIFF
--- a/lib/cequel/util.rb
+++ b/lib/cequel/util.rb
@@ -53,14 +53,10 @@ module Cequel
     module Forwardable
       include ::Forwardable
 
-      def delegate_with_argument_check(*args, &block)
-        if args.size == 1
-          delegate_without_argument_check(args.first)
-        else
-          Module.instance_method(:delegate).bind(self).call(*args, &block)
-        end
+      def delegate(*args, &block)
+        return super if args.size == 1
+        Module.instance_method(:delegate).bind(self).call(*args, &block)
       end
-      alias_method_chain :delegate, :argument_check
     end
   end
 end

--- a/lib/cequel/util.rb
+++ b/lib/cequel/util.rb
@@ -53,9 +53,14 @@ module Cequel
     module Forwardable
       include ::Forwardable
 
-      def delegate(*args, &block)
-        Module.instance_method(:delegate).bind(self).call(*args, &block)
+      def delegate_with_argument_check(*args, &block)
+        if args.size == 1
+          delegate_without_argument_check(args.first)
+        else
+          Module.instance_method(:delegate).bind(self).call(*args, &block)
+        end
       end
+      alias_method_chain :delegate, :argument_check
     end
   end
 end

--- a/lib/cequel/util.rb
+++ b/lib/cequel/util.rb
@@ -54,7 +54,7 @@ module Cequel
       include ::Forwardable
 
       def delegate(*args, &block)
-        return super if args.size == 1
+        return super if args.one?
         Module.instance_method(:delegate).bind(self).call(*args, &block)
       end
     end


### PR DESCRIPTION
Thank you #218 .

Now, we can this without error (thanks!),

```ruby
class A
  include Cequel::Record

  attr_reader :b
  delegate :meth, to: :b
end
```

but we got a error with following code,

```ruby
class A
  include Cequel::Record

  attr_reader :b
  delegate :meth => :b
end
#=> `ArgumentError: Delegation needs a target. Supply an options hash with a :to key as the last argument (e.g. delegate :hello, to: :greeter).`
```
