### PR TITLE
Handle camel cased methods or methods containing periods

### DIFF
--- a/lib/cequel/metal/data_set.rb
+++ b/lib/cequel/metal/data_set.rb
@@ -605,7 +605,7 @@ module Cequel
       # @return [String] CQL `SELECT` statement encoding this data set's scope.
       #
       def cql
-        statement = Statement.new
+        Statement.new
           .append(select_cql)
           .append(" FROM #{table_name}")
           .append(*row_specifications_cql)
@@ -689,9 +689,9 @@ module Cequel
       end
 
       def select_cql
-        all_columns = select_columns +
-          ttl_columns.map { |column| "TTL(#{column})" } +
-          writetime_columns.map { |column| "WRITETIME(#{column})" }
+        all_columns = select_columns.map{|c| %("#{c}")} +
+          ttl_columns.map { |column| %(TTL("#{column}")) } +
+          writetime_columns.map { |column| %(WRITETIME("#{column}")) }
 
         if all_columns.any?
           "SELECT #{all_columns.join(',')}"
@@ -707,7 +707,7 @@ module Cequel
       def sort_order_cql
         if sort_order.any?
           order = sort_order
-            .map { |column, direction| "#{column} #{direction.to_s.upcase}" }
+            .map { |column, direction| %("#{column}" #{direction.to_s.upcase}) }
             .join(', ')
           " ORDER BY #{order}"
         end

--- a/lib/cequel/metal/data_set.rb
+++ b/lib/cequel/metal/data_set.rb
@@ -689,7 +689,7 @@ module Cequel
       end
 
       def select_cql
-        all_columns = select_columns.map{|c| %("#{c}")} +
+        all_columns = select_columns.map { |c| %("#{c}") } +
           ttl_columns.map { |column| %(TTL("#{column}")) } +
           writetime_columns.map { |column| %(WRITETIME("#{column}")) }
 

--- a/lib/cequel/metal/deleter.rb
+++ b/lib/cequel/metal/deleter.rb
@@ -44,7 +44,7 @@ module Cequel
       #
       def list_remove_at(column, *positions)
         statements
-          .concat(positions.map { |position| "#{column}[#{position}]" })
+          .concat(positions.map { |position| %("#{column}"[#{position}]) })
       end
 
       #
@@ -55,7 +55,7 @@ module Cequel
       # @return [void]
       #
       def map_remove(column, *keys)
-        statements.concat(keys.length.times.map { "#{column}[?]" })
+        statements.concat(keys.length.times.map { %("#{column}"[?]) })
         bind_vars.concat(keys)
       end
 

--- a/lib/cequel/metal/deleter.rb
+++ b/lib/cequel/metal/deleter.rb
@@ -31,7 +31,7 @@ module Cequel
       # @return [void]
       #
       def delete_columns(*columns)
-        statements.concat(columns)
+        statements.concat(columns.map { |c| %("#{c}") })
       end
 
       #

--- a/lib/cequel/metal/incrementer.rb
+++ b/lib/cequel/metal/incrementer.rb
@@ -18,7 +18,7 @@ module Cequel
       def increment(data)
         data.each_pair do |column_name, delta|
           operator = delta < 0 ? '-' : '+'
-          statements << "#{column_name} = #{column_name} #{operator} ?"
+          statements << %("#{column_name}" = "#{column_name}" #{operator} ?)
           bind_vars << delta.abs
         end
       end

--- a/lib/cequel/metal/inserter.rb
+++ b/lib/cequel/metal/inserter.rb
@@ -60,7 +60,7 @@ module Cequel
       def write_to_statement(statement, options)
         statement.append("INSERT INTO #{table_name}")
         statement.append(
-          " (#{column_names.map{|c| "\"#{c}\""}.join(', ')}) VALUES (#{statements.join(', ')}) ",
+          " (#{column_names.map{|c| %("#{c}")}.join(', ')}) VALUES (#{statements.join(', ')}) ",
           *bind_vars)
         statement.append(generate_upsert_options(options))
       end

--- a/lib/cequel/metal/inserter.rb
+++ b/lib/cequel/metal/inserter.rb
@@ -59,9 +59,8 @@ module Cequel
 
       def write_to_statement(statement, options)
         statement.append("INSERT INTO #{table_name}")
-        statement.append(
-          " (#{column_names.map{|c| %("#{c}")}.join(', ')}) VALUES (#{statements.join(', ')}) ",
-          *bind_vars)
+        statement.append(" (#{column_names.map { |c| %("#{c}") }.join(', ')})")
+        statement.append(" VALUES (#{statements.join(', ')}) ", *bind_vars)
         statement.append(generate_upsert_options(options))
       end
     end

--- a/lib/cequel/metal/inserter.rb
+++ b/lib/cequel/metal/inserter.rb
@@ -60,7 +60,7 @@ module Cequel
       def write_to_statement(statement, options)
         statement.append("INSERT INTO #{table_name}")
         statement.append(
-          " (#{column_names.join(', ')}) VALUES (#{statements.join(', ')}) ",
+          " (#{column_names.map{|c| "\"#{c}\""}.join(', ')}) VALUES (#{statements.join(', ')}) ",
           *bind_vars)
         statement.append(generate_upsert_options(options))
       end

--- a/lib/cequel/metal/new_relic_instrumentation.rb
+++ b/lib/cequel/metal/new_relic_instrumentation.rb
@@ -17,7 +17,7 @@ module Cequel
         include NewRelic::Agent::MethodTracer
 
         add_method_tracer :execute_with_consistency,
-                          'Database/Cassandra/#{args[0][/^[A-Z ]*[A-Z]/]' \
+                          'Database/Cassandra/#{args[0][/^[A-Z ]*[A-Z]/].to_s' \
                           '.sub(/ FROM$/, \'\')}'
       end
     end

--- a/lib/cequel/metal/row_specification.rb
+++ b/lib/cequel/metal/row_specification.rb
@@ -38,12 +38,12 @@ module Cequel
         case @value
         when Array
           if @value.length == 1
-            ["#{@column} = ?", @value.first]
+            [%("#{@column}" = ?), @value.first]
           else
-            ["#{@column} IN (?)", @value]
+            [%("#{@column}" IN (?)), @value]
           end
         else
-          ["#{@column} = ?", @value]
+          [%("#{@column}" = ?), @value]
         end
       end
     end

--- a/lib/cequel/metal/updater.rb
+++ b/lib/cequel/metal/updater.rb
@@ -45,7 +45,7 @@ module Cequel
       # @see DataSet#list_prepend
       #
       def list_prepend(column, elements)
-        statements << "#{column} = [?] + #{column}"
+        statements << %("#{column}" = [?] + "#{column}")
         bind_vars << elements
       end
 
@@ -59,7 +59,7 @@ module Cequel
       # @see DataSet#list_append
       #
       def list_append(column, elements)
-        statements << "#{column} = #{column} + [?]"
+        statements << %("#{column}" = "#{column}" + [?])
         bind_vars << elements
       end
 
@@ -73,7 +73,7 @@ module Cequel
       # @see DataSet#list_remove
       #
       def list_remove(column, value)
-        statements << "#{column} = #{column} - [?]"
+        statements << %("#{column}" = "#{column}" - [?])
         bind_vars << value
       end
 
@@ -88,7 +88,7 @@ module Cequel
       # @see DataSet#list_replace
       #
       def list_replace(column, index, value)
-        statements << "#{column}[#{index}] = ?"
+        statements << %("#{column}"[#{index}] = ?)
         bind_vars << value
       end
 
@@ -102,7 +102,7 @@ module Cequel
       # @see DataSet#set_add
       #
       def set_add(column, values)
-        statements << "#{column} = #{column} + {?}"
+        statements << %("#{column}" = "#{column}" + {?})
         bind_vars << values
       end
 
@@ -116,7 +116,7 @@ module Cequel
       # @see DataSet#set_remove
       #
       def set_remove(column, values)
-        statements << "#{column} = #{column} - {?}"
+        statements << %("#{column}" = "#{column}" - {?})
         bind_vars << ::Kernel.Array(values)
       end
 
@@ -131,7 +131,7 @@ module Cequel
       #
       def map_update(column, updates)
         binding_pairs = ::Array.new(updates.length) { '?:?' }.join(',')
-        statements << "#{column} = #{column} + {#{binding_pairs}}"
+        statements << %("#{column}" = "#{column}" + {#{binding_pairs}})
         bind_vars.concat(updates.flatten)
       end
 
@@ -155,7 +155,7 @@ module Cequel
         all_statements, all_bind_vars = statements.dup, bind_vars.dup
         column_updates.each_pair do |column, value|
           prepare_upsert_value(value) do |binding, *values|
-            all_statements << "\"#{column}\" = #{binding}"
+            all_statements << %("#{column}" = #{binding})
             all_bind_vars.concat(values)
           end
         end

--- a/lib/cequel/metal/updater.rb
+++ b/lib/cequel/metal/updater.rb
@@ -155,7 +155,7 @@ module Cequel
         all_statements, all_bind_vars = statements.dup, bind_vars.dup
         column_updates.each_pair do |column, value|
           prepare_upsert_value(value) do |binding, *values|
-            all_statements << "#{column} = #{binding}"
+            all_statements << "\"#{column}\" = #{binding}"
             all_bind_vars.concat(values)
           end
         end

--- a/lib/cequel/record/bound.rb
+++ b/lib/cequel/record/bound.rb
@@ -107,7 +107,7 @@ module Cequel
       protected
 
       def to_cql
-        "TOKEN(#{column.name}) #{operator} TOKEN(?)"
+        %(TOKEN("#{column.name}") #{operator} TOKEN(?))
       end
     end
 
@@ -121,7 +121,7 @@ module Cequel
       protected
 
       def to_cql
-        "\"#{column.name}\" #{operator} ?"
+        %("#{column.name}" #{operator} ?)
       end
     end
 
@@ -135,7 +135,7 @@ module Cequel
       protected
 
       def to_cql
-        "\"#{column.name}\" #{operator} #{function}(?)"
+        %("#{column.name}" #{operator} #{function}(?))
       end
 
       def operator

--- a/lib/cequel/record/bound.rb
+++ b/lib/cequel/record/bound.rb
@@ -121,7 +121,7 @@ module Cequel
       protected
 
       def to_cql
-        "#{column.name} #{operator} ?"
+        "\"#{column.name}\" #{operator} ?"
       end
     end
 
@@ -135,7 +135,7 @@ module Cequel
       protected
 
       def to_cql
-        "#{column.name} #{operator} #{function}(?)"
+        "\"#{column.name}\" #{operator} #{function}(?)"
       end
 
       def operator

--- a/lib/cequel/record/finders.rb
+++ b/lib/cequel/record/finders.rb
@@ -80,7 +80,6 @@ module Cequel
         method_suffix = finder_method_suffix(column_names)
         method_name = "#{method_prefix}_#{method_suffix}"
 
-        return if self.respond_to?(method_name)
         singleton_class.send(:define_method, method_name) do |*args|
           query = Hash[column_names.zip(args)]
           scope = where(query)

--- a/lib/cequel/record/finders.rb
+++ b/lib/cequel/record/finders.rb
@@ -80,6 +80,7 @@ module Cequel
         method_suffix = finder_method_suffix(column_names)
         method_name = "#{method_prefix}_#{method_suffix}"
 
+        return if self.respond_to?(method_name)
         singleton_class.send(:define_method, method_name) do |*args|
           query = Hash[column_names.zip(args)]
           scope = where(query)

--- a/lib/cequel/record/properties.rb
+++ b/lib/cequel/record/properties.rb
@@ -200,15 +200,15 @@ module Cequel
         end
 
         def def_reader(name)
-          module_eval <<-RUBY, __FILE__, __LINE__+1
-            def #{name}; read_attribute(#{name.inspect}); end
-          RUBY
+          define_method(name) do
+            read_attribute(name)
+          end
         end
 
         def def_writer(name)
-          module_eval <<-RUBY, __FILE__, __LINE__+1
-            def #{name}=(value); write_attribute(#{name.inspect}, value); end
-          RUBY
+          define_method("#{name}=") do |value|
+            write_attribute(name, value)
+          end
         end
 
         def def_collection_accessors(name, collection_proxy_class)
@@ -217,20 +217,16 @@ module Cequel
         end
 
         def def_collection_reader(name, collection_proxy_class)
-          module_eval <<-RUBY, __FILE__, __LINE__+1
-            def #{name}
-              proxy_collection(#{name.inspect}, #{collection_proxy_class})
-            end
-          RUBY
+          define_method(name) do
+            proxy_collection(name, collection_proxy_class)
+          end
         end
 
         def def_collection_writer(name)
-          module_eval <<-RUBY, __FILE__, __LINE__+1
-            def #{name}=(value)
-              reset_collection_proxy(#{name.inspect})
-              write_attribute(#{name.inspect}, value)
-            end
-          RUBY
+          define_method("#{name}=") do |value|
+            reset_collection_proxy(name)
+            write_attribute(name, value)
+          end
         end
 
         def set_attribute_default(name, default)

--- a/lib/cequel/schema/column.rb
+++ b/lib/cequel/schema/column.rb
@@ -96,7 +96,7 @@ module Cequel
       # @api private
       #
       def to_cql
-        "#{@name} #{@type}"
+        "\"#{@name}\" #{@type}"
       end
 
       #
@@ -221,7 +221,7 @@ module Cequel
     class List < CollectionColumn
       # (see Column#to_cql)
       def to_cql
-        "#{@name} LIST <#{@type}>"
+        "\"#{@name}\" LIST <#{@type}>"
       end
 
       #
@@ -241,7 +241,7 @@ module Cequel
     class Set < CollectionColumn
       # (see Column#to_cql)
       def to_cql
-        "#{@name} SET <#{@type}>"
+        "\"#{@name}\" SET <#{@type}>"
       end
 
       #
@@ -277,7 +277,7 @@ module Cequel
 
       # (see Column#to_cql)
       def to_cql
-        "#{@name} MAP <#{@key_type}, #{@type}>"
+        "\"#{@name}\" MAP <#{@key_type}, #{@type}>"
       end
 
       #

--- a/lib/cequel/schema/column.rb
+++ b/lib/cequel/schema/column.rb
@@ -96,7 +96,7 @@ module Cequel
       # @api private
       #
       def to_cql
-        "\"#{@name}\" #{@type}"
+        %("#{@name}" #{@type})
       end
 
       #
@@ -164,7 +164,7 @@ module Cequel
 
       # @private
       def clustering_order_cql
-        "#{@name} #{@clustering_order}"
+        %("#{@name}" #{@clustering_order})
       end
     end
 
@@ -221,7 +221,7 @@ module Cequel
     class List < CollectionColumn
       # (see Column#to_cql)
       def to_cql
-        "\"#{@name}\" LIST <#{@type}>"
+        %("#{@name}" LIST <#{@type}>)
       end
 
       #
@@ -241,7 +241,7 @@ module Cequel
     class Set < CollectionColumn
       # (see Column#to_cql)
       def to_cql
-        "\"#{@name}\" SET <#{@type}>"
+        %("#{@name}" SET <#{@type}>)
       end
 
       #
@@ -277,7 +277,7 @@ module Cequel
 
       # (see Column#to_cql)
       def to_cql
-        "\"#{@name}\" MAP <#{@key_type}, #{@type}>"
+        %("#{@name}" MAP <#{@key_type}, #{@type}>)
       end
 
       #

--- a/lib/cequel/schema/table_property.rb
+++ b/lib/cequel/schema/table_property.rb
@@ -41,7 +41,7 @@ module Cequel
       #   TABLE` statement
       #
       def to_cql
-        "\"#{@name}\" = #{value_cql}"
+        %("#{@name}" = #{value_cql})
       end
 
       protected

--- a/lib/cequel/schema/table_property.rb
+++ b/lib/cequel/schema/table_property.rb
@@ -41,7 +41,7 @@ module Cequel
       #   TABLE` statement
       #
       def to_cql
-        "#{@name} = #{value_cql}"
+        "\"#{@name}\" = #{value_cql}"
       end
 
       protected

--- a/lib/cequel/schema/table_updater.rb
+++ b/lib/cequel/schema/table_updater.rb
@@ -139,7 +139,7 @@ module Cequel
       def create_index(column_name, index_name = nil)
         index_name ||= "#{table_name}_#{column_name}_idx"
         statements <<
-          "CREATE INDEX #{index_name} ON #{table_name} (#{column_name})"
+          "CREATE INDEX #{index_name} ON #{table_name} (\"#{column_name}\")"
       end
 
       #

--- a/lib/cequel/schema/table_updater.rb
+++ b/lib/cequel/schema/table_updater.rb
@@ -100,7 +100,7 @@ module Cequel
       #   Altering column types is not recommended.
       #
       def change_column(name, type)
-        alter_table("ALTER #{name} TYPE #{type(type).cql_name}")
+        alter_table(%(ALTER "#{name}" TYPE #{type(type).cql_name}))
       end
 
       #
@@ -139,7 +139,7 @@ module Cequel
       def create_index(column_name, index_name = nil)
         index_name ||= "#{table_name}_#{column_name}_idx"
         statements <<
-          "CREATE INDEX #{index_name} ON #{table_name} (\"#{column_name}\")"
+          %(CREATE INDEX #{index_name} ON #{table_name} ("#{column_name}"))
       end
 
       #

--- a/lib/cequel/schema/table_writer.rb
+++ b/lib/cequel/schema/table_writer.rb
@@ -56,8 +56,8 @@ module Cequel
           table.data_columns.each do |column|
             if column.indexed?
               statements <<
-                "CREATE INDEX #{column.index_name} " \
-                "ON #{table.name} (#{column.name})"
+                %(CREATE INDEX #{column.index_name} \
+                  ON #{table.name} ("#{column.name}"))
             end
           end
         end
@@ -73,10 +73,10 @@ module Cequel
 
       def keys_cql
         partition_cql = table.partition_key_columns
-          .map { |key| key.name }.join(', ')
+          .map { |key| %("#{key.name}") }.join(', ')
         if table.clustering_columns.any?
           nonpartition_cql =
-            table.clustering_columns.map { |key| key.name }.join(', ')
+            table.clustering_columns.map { |key| %("#{key.name}") }.join(', ')
           "PRIMARY KEY ((#{partition_cql}), #{nonpartition_cql})"
         else
           "PRIMARY KEY ((#{partition_cql}))"

--- a/spec/examples/metal/data_set_spec.rb
+++ b/spec/examples/metal/data_set_spec.rb
@@ -718,4 +718,206 @@ describe Cequel::Metal::DataSet do
     end
   end
 
+  describe "columns with capital letters and periods" do
+    before :each do
+      cequel.schema.create_table(:legacy_posts) do
+        key :"Blog_subdomain.column", :text
+        key :"Permalink.column", :text
+        column :"Title.column", :text
+        column :"Body.column", :text
+        column :"Published_at.column", :timestamp
+        list :"Categories.column", :text
+        set :"Tags.column", :text
+        map :"Trackbacks.column", :timestamp, :text
+      end
+      cequel.schema.create_table(:legacy_post_activity) do
+        key :"Blog_subdomain.column", :text
+        key :"Permalink.column", :text
+        column :"Visits.column", :counter
+        column :"Tweets.column", :counter
+      end
+    end
+
+    after :each do
+      cequel.schema.drop_table(:legacy_posts)
+      cequel.schema.drop_table(:legacy_post_activity)
+    end
+
+    let(:now) { Time.now }
+    let(:epoch) { Time.at(0) }
+
+    let(:row_keys) do
+      {
+        :"Blog_subdomain.column" => "blog_subdomain",
+        :"Permalink.column" => "permalink",
+      }
+    end
+
+    let(:post_fields) do
+      row_keys.merge({
+        :"Title.column" => "title",
+        :"Body.column" => "body",
+        :"Published_at.column" => now,
+        :"Categories.column" => ["category1", "category2"],
+        :"Tags.column" => Set["tag1", "tag2"],
+        :"Trackbacks.column" => { now => 'www.google.com' }
+      })
+    end
+
+    let(:non_key_update_fields) do
+      {
+        :"Title.column" => "title updated",
+        :"Body.column" => "body updated",
+        :"Published_at.column" => epoch,
+        :"Categories.column" => ["category1 updated", "category2"],
+        :"Tags.column" => Set["tag1 updated", "tag2"],
+        :"Trackbacks.column" => {epoch => 'www.google.com'}
+      }
+    end
+
+    let(:post_fields_updated) do
+      row_keys.merge(non_key_update_fields)
+    end
+
+    let(:post_activity_fields) do
+      row_keys.merge({
+        :"Visits.column" => 5,
+        :"Tweets.column" => 5
+      })
+    end
+
+    it 'should insert when columns have capital letters and periods' do
+      cequel[:legacy_posts].insert(post_fields)
+      row = cequel[:legacy_posts].where(row_keys).first
+      expect(
+        row.each_with_object({}) {|(k,v), hash| hash[k.to_s] = v.inspect}
+      ).to eq(
+        post_fields.each_with_object({}) {|(k,v), hash| hash[k.to_s] = v.inspect}
+      )
+    end
+
+    it "should update" do
+      cequel[:legacy_posts].insert(post_fields)
+      cequel[:legacy_posts].where(row_keys).
+        update(non_key_update_fields)
+
+      row = cequel[:legacy_posts].where(row_keys).first
+      expect(
+        row.each_with_object({}) {|(k,v), hash| hash[k.to_s] = v.inspect}
+      ).to eq(
+        post_fields_updated.each_with_object({}) {|(k,v), hash| hash[k.to_s] = v.inspect}
+      )
+    end
+
+    it "should delete from list" do
+      cequel[:legacy_posts].insert(post_fields)
+      cequel[:legacy_posts].
+        where(row_keys).
+        list_remove_at(:"Categories.column", 0)
+      row = cequel[:legacy_posts].where(row_keys).first
+      expect(row[:"Categories.column"]).to eq ["category2"]
+    end
+
+    it "should preprend to list" do
+      cequel[:legacy_posts].insert(post_fields)
+      cequel[:legacy_posts].
+        where(row_keys).
+        list_prepend(:"Categories.column", ["category0"])
+      row = cequel[:legacy_posts].where(row_keys).first
+      expect(row[:"Categories.column"]).to eq ["category0", "category1", "category2"]
+    end
+
+    it "should append to list" do
+      cequel[:legacy_posts].insert(post_fields)
+      cequel[:legacy_posts].
+        where(row_keys).
+        list_append(:"Categories.column", ["category3"])
+      row = cequel[:legacy_posts].where(row_keys).first
+      expect(row[:"Categories.column"]).to eq ["category1", "category2", "category3"]
+    end
+
+    it "should remove from list" do
+      cequel[:legacy_posts].insert(post_fields)
+      cequel[:legacy_posts].
+        where(row_keys).
+        list_remove(:"Categories.column", ["category2"])
+      row = cequel[:legacy_posts].where(row_keys).first
+      expect(row[:"Categories.column"]).to eq ["category1"]
+    end
+
+    it "should replace from list" do
+      cequel[:legacy_posts].insert(post_fields)
+      cequel[:legacy_posts].
+        where(row_keys).
+        list_replace(:"Categories.column", 0, "category0")
+      row = cequel[:legacy_posts].where(row_keys).first
+      expect(row[:"Categories.column"]).to eq ["category0", "category2"]
+    end
+
+    it "should delete from set" do
+      cequel[:legacy_posts].insert(post_fields)
+      cequel[:legacy_posts].
+        where(row_keys).
+        set_remove(:"Tags.column", "tag1")
+      row = cequel[:legacy_posts].where(row_keys).first
+      expect(row[:"Tags.column"]).to eq Set["tag2"]
+    end
+
+    it "should add to set" do
+      cequel[:legacy_posts].insert(post_fields)
+      cequel[:legacy_posts].
+        where(row_keys).
+        set_add(:"Tags.column", "tag3")
+      row = cequel[:legacy_posts].where(row_keys).first
+      expect(row[:"Tags.column"]).to eq Set["tag1", "tag2", "tag3"]
+    end
+
+    it "should delete from map" do
+      cequel[:legacy_posts].insert(post_fields)
+      cequel[:legacy_posts].
+        where(row_keys).
+        map_remove(:"Trackbacks.column", now)
+      row = cequel[:legacy_posts].where(row_keys).first
+
+      expect(row[:"Trackbacks.column"]).to be_nil
+    end
+
+    it "should update map" do
+      cequel[:legacy_posts].insert(post_fields)
+      cequel[:legacy_posts].
+        where(row_keys).
+        map_update(:"Trackbacks.column", {now => "moc.elgoog.www"})
+      row = cequel[:legacy_posts].where(row_keys).first
+
+      expect(row[:"Trackbacks.column"].size).to eq 1
+      expect(row[:"Trackbacks.column"].keys.first.to_i).to eq now.to_i
+      expect(row[:"Trackbacks.column"].values.first).to eq "moc.elgoog.www"
+    end
+
+    it 'should increment' do
+      cequel[:legacy_post_activity].
+        where(row_keys).
+        increment(:"Visits.column" => 1, :"Tweets.column" => 2)
+
+      row = cequel[:legacy_post_activity].where(row_keys).first
+
+      expect(row[:"Visits.column"]).to eq(1)
+      expect(row[:"Tweets.column"]).to eq(2)
+    end
+
+    it 'should include ttl argument' do
+      cequel[:legacy_posts].insert(post_fields, :ttl => 10.minutes)
+      expect(cequel[:legacy_posts].select_ttl(:"Title.column").where(row_keys).first.ttl(:"Title.column")).
+        to be_within(5).of(10.minutes)
+    end
+
+    it 'should include timestamp argument' do
+      cequel.schema.truncate_table(:legacy_posts)
+      time = 1.day.ago
+      cequel[:legacy_posts].insert(post_fields, :timestamp => time)
+      expect(cequel[:legacy_posts].select_writetime(:"Title.column").where(row_keys).
+        first.writetime(:"Title.column")).to eq((time.to_f * 1_000_000).to_i)
+    end
+  end
+
 end

--- a/spec/examples/metal/data_set_spec.rb
+++ b/spec/examples/metal/data_set_spec.rb
@@ -35,14 +35,17 @@ describe Cequel::Metal::DataSet do
   let(:row_keys) { {blog_subdomain: 'cassandra', permalink: 'big-data'} }
 
   describe '#insert' do
+    let(:now) { Time.at(Time.now.to_i) }
+    let(:one_minute_ago) { Time.at(Time.now.to_i - 60) }
+
     let(:row) do
       row_keys.merge(
         title: 'Fun times',
         categories: ['Fun', 'Profit'],
         tags: Set['cassandra', 'big-data'],
         trackbacks: {
-          Time.at(Time.now.to_i) => 'www.google.com',
-          Time.at(Time.now.to_i - 60) => 'www.yahoo.com'
+          now => 'www.google.com',
+          one_minute_ago => 'www.yahoo.com'
         }
       )
     end
@@ -743,7 +746,7 @@ describe Cequel::Metal::DataSet do
       cequel.schema.drop_table(:legacy_post_activity)
     end
 
-    let(:now) { Time.now }
+    let(:now) { Time.at(Time.now.to_i) }
     let(:epoch) { Time.at(0) }
 
     let(:row_keys) do

--- a/spec/examples/metal/data_set_spec.rb
+++ b/spec/examples/metal/data_set_spec.rb
@@ -809,6 +809,16 @@ describe Cequel::Metal::DataSet do
       )
     end
 
+    it "should delete a field" do
+      cequel[:legacy_posts].insert(post_fields)
+      cequel[:legacy_posts].
+        where(row_keys).
+        delete(:"Title.column", :"Body.column")
+      row = cequel[:legacy_posts].where(row_keys).first
+      expect(row[:"Title.column"]).to be nil
+      expect(row[:"Body.column"]).to be nil
+    end
+
     it "should delete from list" do
       cequel[:legacy_posts].insert(post_fields)
       cequel[:legacy_posts].

--- a/spec/examples/record/finders_spec.rb
+++ b/spec/examples/record/finders_spec.rb
@@ -274,31 +274,4 @@ describe Cequel::Record::Finders do
       end
     end
   end
-
-  context "when defining methods" do
-    it "only defines a finder once per key" do
-      clazz = Class.new do
-        include Cequel::Record
-        self.table_name = name.to_s.tableize + "_" + SecureRandom.hex(4)
-      end
-
-      methods_called = []
-      # calling and_call_original doesn't appear to work with 
-      # define_method and/or singleton_class. Hence the method capture
-      original_define_method = clazz.singleton_class.method(:define_method)
-      expect(clazz.singleton_class).to receive(:define_method) do |method_name, &block|
-        methods_called << method_name
-        clazz.singleton_class.instance_eval do
-          original_define_method.call(method_name, &block)
-        end
-      end.at_least(:once)
-
-      clazz.class_eval do
-        key :first_key, :text
-        key :second_key, :text
-      end
-
-      expect(methods_called).to match_array methods_called.uniq
-    end
-  end
 end

--- a/spec/examples/record/persistence_spec.rb
+++ b/spec/examples/record/persistence_spec.rb
@@ -257,9 +257,13 @@ describe Cequel::Record::Persistence do
       end
 
       it 'should destroy with specified timestamp' do
-        blog = Blog.create(subdomain: 'big-data', name: 'Big Data')
-        blog.destroy(timestamp: 1.minute.ago)
-        expect(cequel[Blog.table_name].where(subdomain: 'big-data').first).to be
+        blog = Blog.new(subdomain: 'big-data2', name: 'Big Data', description: "something")
+        now = Time.now
+        blog.save!(timestamp: now)
+        blog.destroy(timestamp: 10.minute.ago)
+        expect(cequel[Blog.table_name].where(subdomain: 'big-data2').first).to be
+        blog.destroy(timestamp: now)
+        expect(cequel[Blog.table_name].where(subdomain: 'big-data2').first).to_not be
       end
     end
   end

--- a/spec/examples/record/persistence_spec.rb
+++ b/spec/examples/record/persistence_spec.rb
@@ -5,6 +5,8 @@ describe Cequel::Record::Persistence do
   model :Blog do
     key :subdomain, :text
     column :name, :text
+    column :camelCaseColumn, :text
+    column :"column.with.periods", :text
     column :description, :text
     column :owner_id, :uuid
   end
@@ -24,6 +26,8 @@ describe Cequel::Record::Persistence do
       Blog.new do |blog|
         blog.subdomain = 'cequel'
         blog.name = 'Cequel'
+        blog.camelCaseColumn = 'cequelCequel'
+        blog.send("column.with.periods=", 'cequel.cequel')
         blog.description = 'A Ruby ORM for Cassandra 1.2'
       end.tap(&:save)
     end
@@ -37,6 +41,8 @@ describe Cequel::Record::Persistence do
       context 'on create' do
         it 'should save row to database' do
           expect(subject[:name]).to eq('Cequel')
+          expect(subject["column.with.periods"]).to eq('cequel.cequel')
+          expect(subject["camelCaseColumn"]).to eq('cequelCequel')
         end
 
         it 'should mark row persisted' do
@@ -211,13 +217,15 @@ describe Cequel::Record::Persistence do
 
     describe '#update_attributes' do
       let! :blog do
-        Blog.create(:subdomain => 'big-data', :name => 'Big Data')
+        Blog.create(:subdomain => 'big-data', :name => 'Big Data', :"column.with.periods" => "cequel.cequel", :camelCaseColumn => 'cequelCequel')
       end
 
-      before { blog.update_attributes(:name => 'The Big Data Blog') }
+      before { blog.update_attributes(:name => 'The Big Data Blog', :"column.with.periods" => "Cequel.Cequel", :camelCaseColumn => 'CequelCequel') }
 
       it 'should update instance in memory' do
         expect(blog.name).to eq('The Big Data Blog')
+        expect(blog[:"column.with.periods"]).to eq('Cequel.Cequel')
+        expect(blog[:"camelCaseColumn"]).to eq('CequelCequel')
       end
 
       it 'should save instance' do

--- a/spec/examples/record/properties_spec.rb
+++ b/spec/examples/record/properties_spec.rb
@@ -7,6 +7,7 @@ describe Cequel::Record::Properties do
     model :Post do
       key :permalink, :text
       column :title, :text
+      column :"column.with.periods", :text
       list :tags, :text
       set :categories, :text
       map :shares, :text, :int
@@ -32,6 +33,10 @@ describe Cequel::Record::Properties do
 
     it 'should provide accessor for data column' do
       expect(Post.new { |post| post.title = 'Big Data' }.title).to eq('Big Data')
+    end
+
+    it 'should provide accessor for columns with periods' do
+      expect(Post.new { |post| post.send("column.with.periods=", 'Small Data') }.send("column.with.periods")).to eq('Small Data')
     end
 
     it 'should cast data column to correct value' do

--- a/spec/examples/schema/table_updater_spec.rb
+++ b/spec/examples/schema/table_updater_spec.rb
@@ -19,11 +19,16 @@ describe Cequel::Schema::TableUpdater do
     before do
       cequel.schema.alter_table(:posts) do
         add_column :published_at, :timestamp
+        add_column :"Published.at", :timestamp
       end
     end
 
     it 'should add the column with the given type' do
       expect(table.data_column(:published_at).type).to eq(Cequel::Type[:timestamp])
+    end
+
+    it 'should add a column with capital letters and periods' do
+      expect(table.data_column(:"Published.at").type).to eq(Cequel::Type[:timestamp])
     end
   end
 
@@ -31,6 +36,7 @@ describe Cequel::Schema::TableUpdater do
     before do
       cequel.schema.alter_table(:posts) do
         add_list :author_names, :text
+        add_list :"Author.names", :text
       end
     end
 
@@ -41,32 +47,44 @@ describe Cequel::Schema::TableUpdater do
     it 'should set the given type' do
       expect(table.data_column(:author_names).type).to eq(Cequel::Type[:text])
     end
+
+    it 'should add a list with capital letters and periods' do
+      expect(table.data_column(:"Author.names")).to be_a(Cequel::Schema::List)
+    end
+
   end
 
   describe '#add_set' do
     before do
       cequel.schema.alter_table(:posts) do
         add_set :author_names, :text
+        add_set :"Author.names", :text
       end
     end
 
-    it 'should add the list' do
+    it 'should add the set' do
       expect(table.data_column(:author_names)).to be_a(Cequel::Schema::Set)
     end
 
     it 'should set the given type' do
       expect(table.data_column(:author_names).type).to eq(Cequel::Type[:text])
     end
+
+    it 'should add the set with capital letters and periods' do
+      expect(table.data_column(:"Author.names")).to be_a(Cequel::Schema::Set)
+    end
+
   end
 
   describe '#add_map' do
     before do
       cequel.schema.alter_table(:posts) do
         add_map :trackbacks, :timestamp, :ascii
+        add_map :"Track.backs", :timestamp, :ascii
       end
     end
 
-    it 'should add the list' do
+    it 'should add the map' do
       expect(table.data_column(:trackbacks)).to be_a(Cequel::Schema::Map)
     end
 
@@ -79,30 +97,69 @@ describe Cequel::Schema::TableUpdater do
       expect(table.data_column(:trackbacks).value_type).
         to eq(Cequel::Type[:ascii])
     end
+
+    it 'should add the map when the name has capital letter and periods' do
+      expect(table.data_column(:"Track.backs")).to be_a(Cequel::Schema::Map)
+    end
   end
 
   describe '#change_column' do
-    before do
-      cequel.schema.alter_table(:posts) do
-        change_column :title, :text
+    describe "regular columns" do
+      before do
+        cequel.schema.alter_table(:posts) do
+          change_column :title, :text
+        end
+      end
+
+      it 'should change the type' do
+        expect(table.data_column(:title).type).to eq(Cequel::Type[:text])
       end
     end
 
-    it 'should change the type' do
-      expect(table.data_column(:title).type).to eq(Cequel::Type[:text])
+    describe "columns with special characters" do
+      before do
+        cequel.schema.alter_table(:posts) do
+          add_column :"New.Column", :ascii
+        end
+        cequel.schema.alter_table(:posts) do
+          change_column :"New.Column", :text
+        end
+      end
+
+      it 'should change the type for columns with capital letters and periods' do
+        expect(table.data_column(:"New.Column").type).to eq(Cequel::Type[:text])
+      end
     end
   end
 
   describe '#rename_column' do
-    before do
-      cequel.schema.alter_table(:posts) do
-        rename_column :permalink, :slug
+    describe "regular columns" do
+      before do
+        cequel.schema.alter_table(:posts) do
+          rename_column :permalink, :slug
+        end
+      end
+
+      it 'should change the name' do
+        expect(table.clustering_column(:slug)).to be
+        expect(table.clustering_column(:permalink)).to be_nil
       end
     end
 
-    it 'should change the name' do
-      expect(table.clustering_column(:slug)).to be
-      expect(table.clustering_column(:permalink)).to be_nil
+    describe "columns with special characters" do
+      before do
+        cequel.schema.alter_table(:posts) do
+          rename_column :permalink, :"Sl.ug"
+        end
+        cequel.schema.alter_table(:posts) do
+          rename_column :"Sl.ug", :"Perma.Link"
+        end
+      end
+
+      it 'should change the name' do
+        expect(table.clustering_column(:"Perma.Link")).to be
+        expect(table.clustering_column(:permalink)).to be_nil
+      end
     end
   end
 
@@ -119,40 +176,87 @@ describe Cequel::Schema::TableUpdater do
   end
 
   describe '#add_index' do
-    before do
-      cequel.schema.alter_table(:posts) do
-        create_index :title
+    describe "regular columns" do
+      before do
+        cequel.schema.alter_table(:posts) do
+          create_index :title
+        end
+      end
+
+      it 'should add the index' do
+        expect(table.data_column(:title)).to be_indexed
       end
     end
 
-    it 'should add the index' do
-      expect(table.data_column(:title)).to be_indexed
+    describe "column names with camel case and periods" do
+      before do
+        cequel.schema.alter_table(:posts) do
+          add_column :"New.Column", :text
+          create_index :"New.Column", :new_column_index_name
+        end
+      end
+
+      it 'should add the index' do
+        expect(table.data_column(:"New.Column")).to be_indexed
+      end
     end
   end
 
   describe '#drop_index' do
-    before do
-      cequel.schema.alter_table(:posts) do
-        create_index :title
-        drop_index :posts_title_idx
+    describe "regular columns" do
+      before do
+        cequel.schema.alter_table(:posts) do
+          create_index :title
+          drop_index :posts_title_idx
+        end
+      end
+
+      it 'should drop the index' do
+        expect(table.data_column(:title)).not_to be_indexed
       end
     end
 
-    it 'should drop the index' do
-      expect(table.data_column(:title)).not_to be_indexed
+    describe "column names with camel case and periods" do
+      before do
+        cequel.schema.alter_table(:posts) do
+          add_column :"New.Column", :text
+          create_index :"New.Column", :new_column_index_name
+          drop_index :new_column_index_name
+        end
+      end
+
+      it 'should drop the index' do
+        expect(table.data_column(:"New.Column")).not_to be_indexed
+      end
     end
   end
 
   describe '#drop_column' do
-    before do
-      pending 'Support in a future Cassandra version'
-      cequel.schema.alter_table(:posts) do
-        drop_column :body
+    describe "regular columns" do
+      before do
+        pending 'Support in a future Cassandra version'
+        cequel.schema.alter_table(:posts) do
+          drop_column :body
+        end
+      end
+
+      it 'should remove the column' do
+        expect(table.data_column(:body)).to be_nil
       end
     end
 
-    it 'should remove the column' do
-      expect(table.data_column(:body)).to be_nil
+    describe "columns with capital letters and periods" do
+      before do
+        pending 'Support in a future Cassandra version'
+        cequel.schema.alter_table(:posts) do
+          add_column :"New.Column", :text
+          drop_column :"New.Column"
+        end
+      end
+
+      it 'should remove the column' do
+        expect(table.data_column(:"New.Column")).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
I was spiking using your gem for an app that has an existing table schema with columns that have camel cased names and names with periods in them. In CQL, these just need to be escaped with quotes. I've gone through and changed all the places that generate CQL that would need to be changed to handle this.

The associated specs I modified failed before I added the non-test code to fix them, let me know if other specs are needed.

This was tested with Cassandra 2.0.8.39.
