### PR TITLE
add two rake tasks for keyspace

### DIFF
--- a/lib/cequel/record/tasks.rb
+++ b/lib/cequel/record/tasks.rb
@@ -9,8 +9,26 @@ namespace :cequel do
       create!
     end
 
+    desc 'Initialize Cassandra keyspace if not exist'
+    task :create_if_not_exist => :environment do
+      if Cequel::Record.connection.schema.exists?
+        puts "Keyspace #{Cequel::Record.connection.name} already exists. Nothing to do."
+        next
+      end
+      create!
+    end
+
     desc 'Drop Cassandra keyspace'
     task :drop => :environment do
+      drop!
+    end
+
+    desc 'Drop Cassandra keyspace if exist'
+    task :drop_if_exist => :environment do
+      unless Cequel::Record.connection.schema.exists?
+        puts "Keyspace #{Cequel::Record.connection.name} doesn't exist. Nothing to do."
+        next
+      end
       drop!
     end
   end


### PR DESCRIPTION
Add rake tasks:
* cequel:keyspace:create_if_not_exist
* cequel:keyspace:drop_if_exist

Would love to have the ability to avoid getting the error if keyspace already exists.