### PR TITLE
Fixing integration with ActiveModel::Serialization

### DIFF
--- a/lib/cequel/record/properties.rb
+++ b/lib/cequel/record/properties.rb
@@ -256,11 +256,11 @@ module Cequel
       end
 
       #
-      # @return [Hash<Symbol,Object>] map of column names to values currently
+      # @return [Hash<String,Object>] map of column names to values currently
       #   set on this record
       #
       def attributes
-        attribute_names.each_with_object({}) do |name, attributes|
+        attribute_names.each_with_object(HashWithIndifferentAccess.new) do |name, attributes|
           attributes[name] = read_attribute(name)
         end
       end

--- a/spec/examples/record/properties_spec.rb
+++ b/spec/examples/record/properties_spec.rb
@@ -53,6 +53,12 @@ describe Cequel::Record::Properties do
         title).to eq('Big Data')
     end
 
+    it 'should get attributes with indifferent access' do
+      post = Post.new.tap { |post| post.attributes = {:downcased_title => 'big data' }}
+      expect(post.attributes[:title]).to eq 'Big Data'
+      expect(post.attributes["title"]).to eq 'Big Data'
+    end
+
     it 'should take attribute arguments to ::new' do
       expect(Post.new(:downcased_title => 'big data').title).to eq('Big Data')
     end

--- a/spec/examples/record/serialization_spec.rb
+++ b/spec/examples/record/serialization_spec.rb
@@ -19,9 +19,19 @@ describe 'serialization' do
     }
   end
 
-  it 'should provide JSON serialization' do
+  let(:post){ Post.new(attributes) }
+
+  before :each do
     Post.include_root_in_json = false
-    expect(Post.new(attributes).as_json.symbolize_keys).
-      to eq(attributes.merge(body: nil))
+  end
+
+  it 'should provide JSON serialization' do
+    json = post.as_json.symbolize_keys
+    expect(json).to eq(attributes.merge(body: nil))
+  end
+
+  it 'should be able to serialize restricting to some attributes' do
+    json = post.as_json(only: [:id]).symbolize_keys
+    expect(json).to eq(id: attributes[:id])
   end
 end


### PR DESCRIPTION
The integration with ActiveModel::Serialization module was failing because it expects Model#attributes keys to be strings and Cequel::Record::Properties.attributes method return a hash with symbols as keys.

To fix that reducing the incompatibility between versions I changed the #attributes method to return a hash with indifferent access (as was advised by @outoftime in #195).

Because of this bug, the ``#as_json`` with ``:only`` option was returning ``{}`` always. 

Related issues : #194 #195.