### PR TITLE
add support for datacenter configuration

### DIFF
--- a/lib/cequel/metal/keyspace.rb
+++ b/lib/cequel/metal/keyspace.rb
@@ -21,6 +21,8 @@ module Cequel
       attr_reader :hosts
       # @return Integer port to connect to Cassandra nodes on
       attr_reader :port
+      # @return [String] name of the current datacenter
+      attr_reader :datacenter
       # @return Integer maximum number of retries to reconnect to Cassandra
       attr_reader :max_retries
       # @return Float delay between retries to reconnect to Cassandra
@@ -132,6 +134,7 @@ module Cequel
         @configuration = configuration
 
         @hosts, @port = extract_hosts_and_port(configuration)
+        @datacenter   = extract_datacenter(configuration)
         @credentials  = extract_credentials(configuration)
         @max_retries  = extract_max_retries(configuration)
         @retry_delay  = extract_retry_delay(configuration)
@@ -313,6 +316,10 @@ module Cequel
         end
 
         [hosts, ports.first || 9042]
+      end
+
+      def extract_datacenter(configuration)
+        configuration.fetch(:datacenter, nil)
       end
 
       def extract_credentials(configuration)

--- a/spec/examples/metal/keyspace_spec.rb
+++ b/spec/examples/metal/keyspace_spec.rb
@@ -104,6 +104,22 @@ describe Cequel::Metal::Keyspace do
     end
   end
 
+  describe "#datacenter" do
+    it "datacenter setting get extracted correctly for sending to cluster" do
+      connect = Cequel.connect host: Cequel::SpecSupport::Helpers.host,
+                           port: Cequel::SpecSupport::Helpers.port,
+                           datacenter: 'current_datacenter'
+
+      expect(connect.datacenter).to eq('current_datacenter')
+    end
+
+    it "default is nil" do
+      connect = Cequel.connect host: Cequel::SpecSupport::Helpers.host,
+                           port: Cequel::SpecSupport::Helpers.port
+      expect(connect.datacenter).to be_nil
+    end
+  end
+
   describe "#execute" do
     let(:statement) { "SELECT id FROM posts" }
 


### PR DESCRIPTION
Hi there,

I've added support for datacenter configuration. When used, the default load balancing policy Cassandra::LoadBalancing::Policies::DCAwareRoundRobin treats it as the local datacenter.

Kind regards
Jens