### PR TITLE
Process timestamp key in RecordSet correctly.

### DIFF
--- a/lib/cequel/record/lazy_record_collection.rb
+++ b/lib/cequel/record/lazy_record_collection.rb
@@ -32,7 +32,7 @@ module Cequel
 
         exploded_key_attributes = [{}].tap do |all_key_attributes|
           key_columns.zip(scoped_key_values) do |column, values|
-            all_key_attributes.replace(Array(values).flat_map do |value|
+            all_key_attributes.replace([values].flatten.compact.flat_map do |value|
               all_key_attributes.map do |key_attributes|
                 key_attributes.merge(column.name => value)
               end

--- a/spec/examples/record/lazy_record_collection_spec.rb
+++ b/spec/examples/record/lazy_record_collection_spec.rb
@@ -1,0 +1,16 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path('../spec_helper', __FILE__)
+
+describe Cequel::Record::LazyRecordCollection do
+  context 'handle timestamp attribute correctly (do not split it to array)' do
+    model :Event do
+      key :timestamp, :timestamp
+      column :value, :text
+    end
+
+    let(:now) { Time.now }
+    let(:event) { Event[now] }
+
+    it { expect(event.attributes).to include(timestamp: now) }
+  end
+end


### PR DESCRIPTION
For example you have a model:

```
class Event
  include Cequel::Record
  key :timestamp, :timestamp
  column :value, :text
end
```

if you will try to create RecordSet for this model you will see incorrect value for `timestamp` column:

```
Event[Time.now] # => #<Event timestamp: any number here but not Time object> 
```

Problem related to unexpected behavior of Array(Time) expression:

```
2.2.3 :007 > Array(DateTime.now)
=> [Fri, 18 Dec 2015 20:58:54 +0300]
2.2.3 :008 > Array(Time.now)
=> [57, 58, 20, 18, 12, 2015, 5, 352, false, "MSK"]
```
So, Array(Time) was changed to [Time].flatten.compact