### PR TITLE
Limit the size of field values written to the log

### DIFF
--- a/lib/cequel/metal/request_logger.rb
+++ b/lib/cequel/metal/request_logger.rb
@@ -51,7 +51,14 @@ module Cequel
       private
 
       def format_for_log(label, timing, statement, bind_vars)
+        bind_vars = bind_vars.map{|it| String === it ? limit_length(it) : it }
         format('%s (%s) %s', label, timing, sanitize(statement, bind_vars))
+      end
+
+      def limit_length(str)
+        return str if str.length < 100
+
+        str[0..25] + "..." + str[-25..-1]
       end
 
       def_delegator 'Cequel::Metal::Keyspace', :sanitize


### PR DESCRIPTION
We have a field that contains very large values (measured in kb). Printing the whole value to the log makes it grow fast and hard to read.