### PR TITLE
Page size and paging state

### DIFF
--- a/lib/cequel/metal/data_set.rb
+++ b/lib/cequel/metal/data_set.rb
@@ -580,7 +580,7 @@ module Cequel
       end
 
       def next_paging_state
-        execute_cql(*cql).paging_state
+        results.paging_state
       end
 
       # rubocop:enable LineLength
@@ -600,8 +600,7 @@ module Cequel
       #
       def each
         return enum_for(:each) unless block_given?
-        result = execute_cql(*cql)
-        result.each { |row| yield Row.from_result_row(row) }
+        results.each { |row| yield Row.from_result_row(row) }
       end
 
       #
@@ -676,6 +675,10 @@ module Cequel
       attr_writer :row_limit, :query_consistency, :query_page_size, :query_paging_state
 
       private
+
+      def results
+        @results ||= execute_cql(*cql)
+      end
 
       def execute_cql(cql, *bind_vars)
         keyspace.execute_with_options(cql, bind_vars, {

--- a/lib/cequel/metal/data_set.rb
+++ b/lib/cequel/metal/data_set.rb
@@ -49,6 +49,7 @@ module Cequel
       # @since 1.1.0
       attr_reader :query_consistency
       attr_reader :query_page_size
+      attr_reader :query_paging_state
 
       def_delegator :keyspace, :write_with_consistency
 
@@ -572,6 +573,11 @@ module Cequel
         end
       end
 
+      def paging_state(paging_state)
+        clone.tap do |data_set|
+          data_set.query_paging_state = paging_state
+        end
+      end
 
       # rubocop:enable LineLength
 
@@ -663,12 +669,16 @@ module Cequel
 
       protected
 
-      attr_writer :row_limit, :query_consistency, :query_page_size
+      attr_writer :row_limit, :query_consistency, :query_page_size, :query_paging_state
 
       private
 
       def execute_cql(cql, *bind_vars)
-        keyspace.execute_with_options(cql, bind_vars, {consistency: query_consistency, page_size: query_page_size})
+        keyspace.execute_with_options(cql, bind_vars, {
+          consistency: query_consistency,
+          page_size: query_page_size,
+          paging_state: query_paging_state
+        })
       end
 
       def inserter(&block)

--- a/lib/cequel/metal/data_set.rb
+++ b/lib/cequel/metal/data_set.rb
@@ -579,6 +579,10 @@ module Cequel
         end
       end
 
+      def next_paging_state
+        execute_cql(*cql).paging_state
+      end
+
       # rubocop:enable LineLength
 
       #

--- a/lib/cequel/metal/data_set.rb
+++ b/lib/cequel/metal/data_set.rb
@@ -48,6 +48,7 @@ module Cequel
       #   use
       # @since 1.1.0
       attr_reader :query_consistency
+      attr_reader :query_page_size
 
       def_delegator :keyspace, :write_with_consistency
 
@@ -565,6 +566,13 @@ module Cequel
         end
       end
 
+      def page_size(page_size)
+        clone.tap do |data_set|
+          data_set.query_page_size = page_size
+        end
+      end
+
+
       # rubocop:enable LineLength
 
       #
@@ -655,12 +663,12 @@ module Cequel
 
       protected
 
-      attr_writer :row_limit, :query_consistency
+      attr_writer :row_limit, :query_consistency, :query_page_size
 
       private
 
       def execute_cql(cql, *bind_vars)
-        keyspace.execute_with_consistency(cql, bind_vars, query_consistency)
+        keyspace.execute_with_options(cql, bind_vars, {consistency: query_consistency, page_size: query_page_size})
       end
 
       def inserter(&block)

--- a/lib/cequel/record/data_set_builder.rb
+++ b/lib/cequel/record/data_set_builder.rb
@@ -41,6 +41,7 @@ module Cequel
         add_order
         set_consistency
         set_page_size
+        set_paging_state
         data_set
       end
 
@@ -52,7 +53,7 @@ module Cequel
                      :scoped_key_names, :scoped_key_values,
                      :scoped_indexed_column, :lower_bound,
                      :upper_bound, :reversed?, :order_by_column,
-                     :query_consistency, :query_page_size, :ascends_by?
+                     :query_consistency, :query_page_size, :query_paging_state, :ascends_by?
 
       private
 
@@ -101,6 +102,12 @@ module Cequel
       def set_page_size
         if query_page_size
           self.data_set = data_set.page_size(query_page_size)
+        end
+      end
+
+      def set_paging_state
+        if query_paging_state
+          self.data_set = data_set.paging_state(query_paging_state)
         end
       end
 

--- a/lib/cequel/record/data_set_builder.rb
+++ b/lib/cequel/record/data_set_builder.rb
@@ -40,6 +40,7 @@ module Cequel
         add_bounds
         add_order
         set_consistency
+        set_page_size
         data_set
       end
 
@@ -51,7 +52,7 @@ module Cequel
                      :scoped_key_names, :scoped_key_values,
                      :scoped_indexed_column, :lower_bound,
                      :upper_bound, :reversed?, :order_by_column,
-                     :query_consistency, :ascends_by?
+                     :query_consistency, :query_page_size, :ascends_by?
 
       private
 
@@ -94,6 +95,12 @@ module Cequel
       def set_consistency
         if query_consistency
           self.data_set = data_set.consistency(query_consistency)
+        end
+      end
+
+      def set_page_size
+        if query_page_size
+          self.data_set = data_set.page_size(query_page_size)
         end
       end
 

--- a/lib/cequel/record/record_set.rb
+++ b/lib/cequel/record/record_set.rb
@@ -484,6 +484,10 @@ module Cequel
         scoped(query_paging_state: paging_state)
       end
 
+      def next_paging_state
+        data_set.next_paging_state
+      end
+
       #
       # @overload first
       #   @return [Record] the first record in this record set

--- a/lib/cequel/record/record_set.rb
+++ b/lib/cequel/record/record_set.rb
@@ -475,6 +475,16 @@ module Cequel
       end
 
       #
+      # Set the paging_state at which to read records into the record set.
+      #
+      # @param paging_state [String] paging_state for reads
+      # @return [RecordSet] record set tuned to given paging_state
+      #
+      def paging_state(paging_state)
+        scoped(query_paging_state: paging_state)
+      end
+
+      #
       # @overload first
       #   @return [Record] the first record in this record set
       #
@@ -677,9 +687,11 @@ module Cequel
       attr_reader :attributes
       hattr_reader :attributes, :select_columns, :scoped_key_values,
                    :row_limit, :lower_bound, :upper_bound,
-                   :scoped_indexed_column, :query_consistency, :query_page_size
+                   :scoped_indexed_column, :query_consistency,
+                   :query_page_size, :query_paging_state
       protected :select_columns, :scoped_key_values, :row_limit, :lower_bound,
-                :upper_bound, :scoped_indexed_column, :query_consistency, :query_page_size
+                :upper_bound, :scoped_indexed_column, :query_consistency,
+                :query_page_size, :query_paging_state
       hattr_inquirer :attributes, :reversed
       protected :reversed?
 

--- a/lib/cequel/record/record_set.rb
+++ b/lib/cequel/record/record_set.rb
@@ -465,6 +465,16 @@ module Cequel
       end
 
       #
+      # Set the page_size at which to read records into the record set.
+      #
+      # @param page_size [Integer] page_size for reads
+      # @return [RecordSet] record set tuned to given page_size
+      #
+      def page_size(page_size)
+        scoped(query_page_size: page_size)
+      end
+
+      #
       # @overload first
       #   @return [Record] the first record in this record set
       #
@@ -667,9 +677,9 @@ module Cequel
       attr_reader :attributes
       hattr_reader :attributes, :select_columns, :scoped_key_values,
                    :row_limit, :lower_bound, :upper_bound,
-                   :scoped_indexed_column, :query_consistency
+                   :scoped_indexed_column, :query_consistency, :query_page_size
       protected :select_columns, :scoped_key_values, :row_limit, :lower_bound,
-                :upper_bound, :scoped_indexed_column, :query_consistency
+                :upper_bound, :scoped_indexed_column, :query_consistency, :query_page_size
       hattr_inquirer :attributes, :reversed
       protected :reversed?
 

--- a/spec/examples/metal/data_set_spec.rb
+++ b/spec/examples/metal/data_set_spec.rb
@@ -654,6 +654,30 @@ describe Cequel::Metal::DataSet do
     end
   end
 
+  describe '#page_size' do
+    let(:data_set) { cequel[:posts].page_size(1) }
+
+    it 'should issue SELECT with scoped page size' do
+      expect_query_with_options(/SELECT/, :page_size => 1) { data_set.to_a }
+    end
+
+    it 'should issue COUNT with scoped page size' do
+      expect_query_with_options(/SELECT.*COUNT/, :page_size => 1) { data_set.count }
+    end
+  end
+
+  describe '#paging_state' do
+    let(:data_set) { cequel[:posts].paging_state(nil) }
+
+    it 'should issue SELECT with scoped paging state' do
+      expect_query_with_options(/SELECT/, :paging_state => nil) { data_set.to_a }
+    end
+
+    it 'should issue COUNT with scoped paging state' do
+      expect_query_with_options(/SELECT.*COUNT/, :paging_state => nil) { data_set.count }
+    end
+  end
+
   describe 'result enumeration' do
     let(:row) { row_keys.merge(:title => 'Big Data') }
 

--- a/spec/examples/record/record_set_spec.rb
+++ b/spec/examples/record/record_set_spec.rb
@@ -811,6 +811,41 @@ describe Cequel::Record::RecordSet do
     end
   end
 
+  describe '#page_size' do
+    it 'should return the number of records specified by page_size' do
+      expect(Post.page_size(2).to_a.length).to be(2)
+    end
+  end
+
+  describe '#next_paging_state' do
+    it 'should return the paging state of the result' do
+      expect(Post.page_size(1).next_paging_state).not_to eq(nil)
+    end
+  end
+
+  describe '#paging_state' do
+    let(:page_one) { Post.page_size(1) }
+    let(:page_two) { Post.page_size(1).paging_state(page_one.next_paging_state) }
+    let(:page_size) { 3 }
+
+    it 'should page through all records' do
+      all_pages = []
+      next_paging_state = nil
+
+      loop do
+        a_page = Post.page_size(page_size).paging_state(next_paging_state)
+        next_paging_state = a_page.next_paging_state
+
+        # There may be less than page size records on final page
+        expect(a_page.to_a.length).to be <= page_size
+        all_pages.concat(a_page.to_a)
+        break if next_paging_state.nil?
+      end
+
+      expect(all_pages).to eq(posts.to_a)
+    end
+  end
+
   describe '#count' do
     let(:records) { blogs }
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -139,6 +139,14 @@ module Cequel
         expect(cequel.client).to have_received(:execute).
           with(matcher, hash_including(:consistency => consistency))
       end
+
+      def expect_query_with_options(matcher, options)
+        allow(cequel.client).to receive(:execute).and_call_original
+        yield
+        expect(cequel.client).to have_received(:execute).
+          with(matcher, hash_including(options))
+      end
+
     end
   end
 end


### PR DESCRIPTION
The Cassandra driver supports pagination through a `page_size` and `paging_state`, and this exposes them on the record_set class, much like consistency is, so they can be used.

I haven't written tests for this or run the vagrant tests yet, I wanted to get some initial feedback on if I was going about this in right way beforehand.  