### PR TITLE
Attributes marked as dirty when assigned on a new object.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
+sudo: false
 language: ruby
 rvm:
   - "2.2.0"
   - "2.1.5"
-  - "rbx-2.5.2"
+  - "2.3.0"
   - "jruby-1.7.22"
   - "jruby-9.0.0.0"
 gemfile:
@@ -10,12 +11,6 @@ gemfile:
   - "gemfiles/rails_4.1.gemfile"
   - "gemfiles/rails_4.2.gemfile"
 script: 'bundle exec rake test'
-before_install:
-  - sudo sh -c "echo 'JVM_OPTS=\"\${JVM_OPTS} -Djava.net.preferIPv4Stack=false\"' >> /usr/local/cassandra/conf/cassandra-env.sh"
-  - sudo service cassandra start
 bundler_args: '--without=debug'
 services:
   - cassandra
-matrix:
-  allow_failures:
-    - rvm: "rbx-2.5.2"

--- a/README.md
+++ b/README.md
@@ -519,9 +519,8 @@ the columns that are given.
 
 ### Ruby ###
 
-* Ruby 2.2, 2.1, 2.0
+* Ruby 2.3, 2.2, 2.1, 2.0
 * JRuby 1.7, 9.0
-* Rubinius 2.5
 
 ### Cassandra ###
 

--- a/lib/cequel/record/properties.rb
+++ b/lib/cequel/record/properties.rb
@@ -343,6 +343,8 @@ module Cequel
         unless self.class.reflect_on_column(name)
           fail UnknownAttributeError, "unknown attribute: #{name}"
         end
+
+        send("#{name}_will_change!") unless value === read_attribute(name)
         @attributes[name] = value
       end
 

--- a/spec/examples/record/dirty_spec.rb
+++ b/spec/examples/record/dirty_spec.rb
@@ -59,12 +59,4 @@ describe Cequel::Record::Dirty do
     end
   end
 
-  context 'unloaded model' do
-    let(:post) { Post['cequel'] }
-
-    it 'should not track changes' do
-      post.title = 'Cequel'
-      expect(post.changes).to be_empty
-    end
-  end
 end

--- a/spec/examples/record/properties_spec.rb
+++ b/spec/examples/record/properties_spec.rb
@@ -53,6 +53,11 @@ describe Cequel::Record::Properties do
         title).to eq('Big Data')
     end
 
+    it 'should mark the attribute as dirty when setting attributes' do
+      expect(Post.new { |post| post.title = 'Big Data' }.changed).to eq(['title'])
+      expect(Post.new { |post| post.title = 'Big Data' }.changes).to eq({'title' => [nil,'Big Data']})
+    end
+
     it 'should get attributes with indifferent access' do
       post = Post.new.tap { |post| post.attributes = {:downcased_title => 'big data' }}
       expect(post.attributes[:title]).to eq 'Big Data'

--- a/spec/examples/schema/table_reader_spec.rb
+++ b/spec/examples/schema/table_reader_spec.rb
@@ -2,16 +2,17 @@
 require File.expand_path('../../spec_helper', __FILE__)
 
 describe Cequel::Schema::TableReader do
+  let(:table_name) { :"posts_#{SecureRandom.hex(4)}" }
 
   after do
-    cequel.schema.drop_table(:posts)
+    cequel.schema.drop_table(table_name)
   end
 
-  let(:table) { cequel.schema.read_table(:posts) }
+  let(:table) { cequel.schema.read_table(table_name) }
 
   describe 'reading simple key' do
     before do
-      cequel.execute("CREATE TABLE posts (permalink text PRIMARY KEY)")
+      cequel.execute("CREATE TABLE #{table_name} (permalink text PRIMARY KEY)")
     end
 
     it 'should read name correctly' do
@@ -30,7 +31,7 @@ describe Cequel::Schema::TableReader do
   describe 'reading single non-partition key' do
     before do
       cequel.execute <<-CQL
-        CREATE TABLE posts (
+        CREATE TABLE #{table_name} (
           blog_subdomain text,
           permalink ascii,
           PRIMARY KEY (blog_subdomain, permalink)
@@ -63,7 +64,7 @@ describe Cequel::Schema::TableReader do
   describe 'reading reverse-ordered non-partition key' do
     before do
       cequel.execute <<-CQL
-        CREATE TABLE posts (
+        CREATE TABLE #{table_name} (
           blog_subdomain text,
           permalink ascii,
           PRIMARY KEY (blog_subdomain, permalink)
@@ -89,7 +90,7 @@ describe Cequel::Schema::TableReader do
   describe 'reading compound non-partition key' do
     before do
       cequel.execute <<-CQL
-        CREATE TABLE posts (
+        CREATE TABLE #{table_name} (
           blog_subdomain text,
           permalink ascii,
           author_id uuid,
@@ -116,7 +117,7 @@ describe Cequel::Schema::TableReader do
   describe 'reading compound partition key' do
     before do
       cequel.execute <<-CQL
-        CREATE TABLE posts (
+        CREATE TABLE #{table_name} (
           blog_subdomain text,
           permalink ascii,
           PRIMARY KEY ((blog_subdomain, permalink))
@@ -142,7 +143,7 @@ describe Cequel::Schema::TableReader do
   describe 'reading compound partition and non-partition keys' do
     before do
       cequel.execute <<-CQL
-        CREATE TABLE posts (
+        CREATE TABLE #{table_name} (
           blog_subdomain text,
           permalink ascii,
           author_id uuid,
@@ -183,7 +184,7 @@ describe Cequel::Schema::TableReader do
 
     before do
       cequel.execute <<-CQL
-        CREATE TABLE posts (
+        CREATE TABLE #{table_name} (
           blog_subdomain text,
           permalink ascii,
           title text,
@@ -194,7 +195,7 @@ describe Cequel::Schema::TableReader do
           PRIMARY KEY (blog_subdomain, permalink)
         )
       CQL
-      cequel.execute('CREATE INDEX posts_author_id_idx ON posts (author_id)')
+      cequel.execute("CREATE INDEX posts_author_id_idx ON #{table_name} (author_id)")
     end
 
     it 'should read types of scalar data columns' do
@@ -255,7 +256,7 @@ describe Cequel::Schema::TableReader do
 
     before do
       cequel.execute <<-CQL
-        CREATE TABLE posts (permalink text PRIMARY KEY)
+        CREATE TABLE #{table_name} (permalink text PRIMARY KEY)
         WITH bloom_filter_fp_chance = 0.02
         AND comment = 'Posts table'
         AND compaction = {
@@ -315,7 +316,7 @@ describe Cequel::Schema::TableReader do
   describe 'skinny-row compact storage' do
     before do
       cequel.execute <<-CQL
-        CREATE TABLE posts (permalink text PRIMARY KEY, title text, body text)
+        CREATE TABLE #{table_name} (permalink text PRIMARY KEY, title text, body text)
         WITH COMPACT STORAGE
       CQL
     end
@@ -333,7 +334,7 @@ describe Cequel::Schema::TableReader do
   describe 'wide-row compact storage' do
     before do
       cequel.execute <<-CQL
-        CREATE TABLE posts (
+        CREATE TABLE #{table_name} (
           blog_subdomain text,
           id uuid,
           data text,
@@ -356,7 +357,7 @@ describe Cequel::Schema::TableReader do
   describe 'skinny-row legacy table', thrift: true do
     before do
       legacy_connection.execute <<-CQL
-        CREATE TABLE posts (permalink text PRIMARY KEY, title text, body text)
+        CREATE TABLE #{table_name} (permalink text PRIMARY KEY, title text, body text)
       CQL
     end
     subject { table }
@@ -375,7 +376,7 @@ describe Cequel::Schema::TableReader do
   describe 'wide-row legacy table', thrift: true do
     before do
       legacy_connection.execute(<<-CQL2)
-        CREATE COLUMNFAMILY posts (blog_subdomain text PRIMARY KEY)
+        CREATE COLUMNFAMILY #{table_name} (blog_subdomain text PRIMARY KEY)
         WITH comparator=uuid AND default_validation=text
       CQL2
     end

--- a/spec/examples/schema/table_synchronizer_spec.rb
+++ b/spec/examples/schema/table_synchronizer_spec.rb
@@ -2,12 +2,13 @@
 require File.expand_path('../../spec_helper', __FILE__)
 
 describe Cequel::Schema::TableSynchronizer do
+  let(:table_name) { :"posts_#{SecureRandom.hex(4)}" }
 
-  let(:table) { cequel.schema.read_table(:posts) }
+  let(:table) { cequel.schema.read_table(table_name) }
 
   context 'with no existing table' do
     before do
-      cequel.schema.sync_table :posts do
+      cequel.schema.sync_table table_name do
         key :blog_subdomain, :text
         key :permalink, :text
         column :title, :text
@@ -18,7 +19,7 @@ describe Cequel::Schema::TableSynchronizer do
       end
     end
 
-    after { cequel.schema.drop_table(:posts) }
+    after { cequel.schema.drop_table(table_name) }
 
     it 'should create table' do
       expect(table.column(:title).type).to eq(Cequel::Type[:text]) #etc.
@@ -27,7 +28,7 @@ describe Cequel::Schema::TableSynchronizer do
 
   context 'with an existing table' do
     before do
-      cequel.schema.create_table :posts do
+      cequel.schema.create_table table_name do
         key :blog_subdomain, :text
         key :permalink, :text
         column :title, :ascii, :index => true
@@ -38,12 +39,12 @@ describe Cequel::Schema::TableSynchronizer do
       end
     end
 
-    after { cequel.schema.drop_table(:posts) }
+    after { cequel.schema.drop_table(table_name) }
 
     context 'with valid changes' do
 
       before do
-        cequel.schema.sync_table :posts do
+        cequel.schema.sync_table table_name do
           key :blog_subdomain, :text
           key :post_permalink, :text
           column :title, :ascii
@@ -95,7 +96,7 @@ describe Cequel::Schema::TableSynchronizer do
 
       it 'should not allow changing type of key' do
         expect {
-          cequel.schema.sync_table :posts do
+          cequel.schema.sync_table table_name do
             key :blog_subdomain, :text
             key :permalink, :ascii
             column :title, :ascii
@@ -109,7 +110,7 @@ describe Cequel::Schema::TableSynchronizer do
 
       it 'should not allow adding a key' do
         expect {
-          cequel.schema.sync_table :posts do
+          cequel.schema.sync_table table_name do
             key :blog_subdomain, :text
             key :permalink, :text
             key :year, :int
@@ -124,7 +125,7 @@ describe Cequel::Schema::TableSynchronizer do
 
       it 'should not allow removing a key' do
         expect {
-          cequel.schema.sync_table :posts do
+          cequel.schema.sync_table table_name do
             key :blog_subdomain, :text
             column :title, :ascii
             column :body, :text
@@ -137,7 +138,7 @@ describe Cequel::Schema::TableSynchronizer do
 
       it 'should not allow changing the partition status of a key' do
         expect {
-          cequel.schema.sync_table :posts do
+          cequel.schema.sync_table table_name do
             key :blog_subdomain, :text
             partition_key :permalink, :text
             column :title, :ascii
@@ -151,7 +152,7 @@ describe Cequel::Schema::TableSynchronizer do
 
       it 'should not allow changing the data structure of a column' do
         expect {
-          cequel.schema.sync_table :posts do
+          cequel.schema.sync_table table_name do
             key :blog_subdomain, :text
             key :permalink, :text
             column :title, :ascii
@@ -165,7 +166,7 @@ describe Cequel::Schema::TableSynchronizer do
 
       it 'should not allow invalid type transitions of a data column' do
         expect {
-          cequel.schema.sync_table :posts do
+          cequel.schema.sync_table table_name do
             key :blog_subdomain, :text
             key :permalink, :text
             column :title, :ascii, :index => true
@@ -179,7 +180,7 @@ describe Cequel::Schema::TableSynchronizer do
 
       it 'should not allow changing clustering order' do
         expect {
-          cequel.schema.sync_table :posts do
+          cequel.schema.sync_table table_name do
             key :blog_subdomain, :text
             key :permalink, :text, :desc
             column :title, :ascii, :index => true

--- a/spec/examples/schema/table_updater_spec.rb
+++ b/spec/examples/schema/table_updater_spec.rb
@@ -2,8 +2,10 @@
 require File.expand_path('../../spec_helper', __FILE__)
 
 describe Cequel::Schema::TableUpdater do
+  let(:table_name) { :"posts_#{SecureRandom.hex(4)}" }
+
   before do
-    cequel.schema.create_table(:posts) do
+    cequel.schema.create_table(table_name) do
       key :blog_subdomain, :text
       key :permalink, :text
       column :title, :ascii
@@ -11,13 +13,13 @@ describe Cequel::Schema::TableUpdater do
     end
   end
 
-  after { cequel.schema.drop_table(:posts) }
+  after { cequel.schema.drop_table(table_name) }
 
-  let(:table) { cequel.schema.read_table(:posts) }
+  let(:table) { cequel.schema.read_table(table_name) }
 
   describe '#add_column' do
     before do
-      cequel.schema.alter_table(:posts) do
+      cequel.schema.alter_table(table_name) do
         add_column :published_at, :timestamp
       end
     end
@@ -29,7 +31,7 @@ describe Cequel::Schema::TableUpdater do
 
   describe '#add_list' do
     before do
-      cequel.schema.alter_table(:posts) do
+      cequel.schema.alter_table(table_name) do
         add_list :author_names, :text
       end
     end
@@ -45,7 +47,7 @@ describe Cequel::Schema::TableUpdater do
 
   describe '#add_set' do
     before do
-      cequel.schema.alter_table(:posts) do
+      cequel.schema.alter_table(table_name) do
         add_set :author_names, :text
       end
     end
@@ -61,7 +63,7 @@ describe Cequel::Schema::TableUpdater do
 
   describe '#add_map' do
     before do
-      cequel.schema.alter_table(:posts) do
+      cequel.schema.alter_table(table_name) do
         add_map :trackbacks, :timestamp, :ascii
       end
     end
@@ -83,7 +85,7 @@ describe Cequel::Schema::TableUpdater do
 
   describe '#change_column' do
     before do
-      cequel.schema.alter_table(:posts) do
+      cequel.schema.alter_table(table_name) do
         change_column :title, :text
       end
     end
@@ -95,7 +97,7 @@ describe Cequel::Schema::TableUpdater do
 
   describe '#rename_column' do
     before do
-      cequel.schema.alter_table(:posts) do
+      cequel.schema.alter_table(table_name) do
         rename_column :permalink, :slug
       end
     end
@@ -108,7 +110,7 @@ describe Cequel::Schema::TableUpdater do
 
   describe '#change_properties' do
     before do
-      cequel.schema.alter_table(:posts) do
+      cequel.schema.alter_table(table_name) do
         change_properties :comment => 'Test Comment'
       end
     end
@@ -118,9 +120,23 @@ describe Cequel::Schema::TableUpdater do
     end
   end
 
+  describe '#drop_index' do
+    before do
+      tab_name = table_name
+      cequel.schema.alter_table(table_name) do
+        create_index :title
+        drop_index :"#{tab_name}_title_idx"
+      end
+    end
+
+    it 'should drop the index' do
+      expect(table.data_column(:title)).not_to be_indexed
+    end
+  end
+
   describe '#add_index' do
     before do
-      cequel.schema.alter_table(:posts) do
+      cequel.schema.alter_table(table_name) do
         create_index :title
       end
     end
@@ -130,23 +146,10 @@ describe Cequel::Schema::TableUpdater do
     end
   end
 
-  describe '#drop_index' do
-    before do
-      cequel.schema.alter_table(:posts) do
-        create_index :title
-        drop_index :posts_title_idx
-      end
-    end
-
-    it 'should drop the index' do
-      expect(table.data_column(:title)).not_to be_indexed
-    end
-  end
-
   describe '#drop_column' do
     before do
       pending 'Support in a future Cassandra version'
-      cequel.schema.alter_table(:posts) do
+      cequel.schema.alter_table(table_name) do
         drop_column :body
       end
     end

--- a/spec/examples/schema/table_writer_spec.rb
+++ b/spec/examples/schema/table_writer_spec.rb
@@ -2,18 +2,19 @@
 require File.expand_path('../../spec_helper', __FILE__)
 
 describe Cequel::Schema::TableWriter do
+  let(:table_name) { :"posts_#{SecureRandom.hex(4)}" }
 
-  let(:table) { cequel.schema.read_table(:posts) }
+  let(:table) { cequel.schema.read_table(table_name) }
 
   describe '#create_table' do
 
     after do
-      cequel.schema.drop_table(:posts)
+      cequel.schema.drop_table(table_name)
     end
 
     describe 'with simple skinny table' do
       before do
-        cequel.schema.create_table(:posts) do
+        cequel.schema.create_table(table_name) do
           key :permalink, :ascii
           column :title, :text
         end
@@ -35,7 +36,7 @@ describe Cequel::Schema::TableWriter do
 
     describe 'with multi-column primary key' do
       before do
-        cequel.schema.create_table(:posts) do
+        cequel.schema.create_table(table_name) do
           key :blog_subdomain, :ascii
           key :permalink, :ascii
           column :title, :text
@@ -61,7 +62,7 @@ describe Cequel::Schema::TableWriter do
 
     describe 'with composite partition key' do
       before do
-        cequel.schema.create_table(:posts) do
+        cequel.schema.create_table(table_name) do
           partition_key :blog_subdomain, :ascii
           partition_key :permalink, :ascii
           column :title, :text
@@ -80,7 +81,7 @@ describe Cequel::Schema::TableWriter do
 
     describe 'with composite partition key and non-partition keys' do
       before do
-        cequel.schema.create_table(:posts) do
+        cequel.schema.create_table(table_name) do
           partition_key :blog_subdomain, :ascii
           partition_key :permalink, :ascii
           key :month, :timestamp
@@ -109,7 +110,7 @@ describe Cequel::Schema::TableWriter do
 
     describe 'collection types' do
       before do
-        cequel.schema.create_table(:posts) do
+        cequel.schema.create_table(table_name) do
           key :permalink, :ascii
           column :title, :text
           list :authors, :blob
@@ -151,7 +152,7 @@ describe Cequel::Schema::TableWriter do
 
     describe 'storage properties' do
       before do
-        cequel.schema.create_table(:posts) do
+        cequel.schema.create_table(table_name) do
           key :permalink, :ascii
           column :title, :text
           with :comment, 'Blog posts'
@@ -175,7 +176,7 @@ describe Cequel::Schema::TableWriter do
 
     describe 'compact storage' do
       before do
-        cequel.schema.create_table(:posts) do
+        cequel.schema.create_table(table_name) do
           key :permalink, :ascii
           column :title, :text
           compact_storage
@@ -189,7 +190,7 @@ describe Cequel::Schema::TableWriter do
 
     describe 'clustering order' do
       before do
-        cequel.schema.create_table(:posts) do
+        cequel.schema.create_table(table_name) do
           key :blog_permalink, :ascii
           key :id, :uuid, :desc
           column :title, :text
@@ -203,7 +204,7 @@ describe Cequel::Schema::TableWriter do
 
     describe 'indices' do
       it 'should create indices' do
-        cequel.schema.create_table(:posts) do
+        cequel.schema.create_table(table_name) do
           key :blog_permalink, :ascii
           key :id, :uuid, :desc
           column :title, :text, :index => true
@@ -212,7 +213,7 @@ describe Cequel::Schema::TableWriter do
       end
 
       it 'should create indices with specified name' do
-        cequel.schema.create_table(:posts) do
+        cequel.schema.create_table(table_name) do
           key :blog_permalink, :ascii
           key :id, :uuid, :desc
           column :title, :text, :index => :silly_idx

--- a/spec/examples/spec_support/preparation_spec.rb
+++ b/spec/examples/spec_support/preparation_spec.rb
@@ -49,6 +49,14 @@ describe Cequel::SpecSupport::Preparation do
       Cequel::Record.connection.schema.drop!
     end
 
+    let!(:model) {
+      Class.new do
+        include Cequel::Record
+        self.table_name = "blog_" + SecureRandom.hex(4)
+        key :name, :text
+      end
+    }
+
     it "doesn't cause failure upon drop requests" do
       expect{ prep.drop_keyspace }.not_to raise_error
     end


### PR DESCRIPTION
This change brings Cequel models into line with regular ActiveRecord
model behaviour.

```ruby
p = Post.new(title: 'My Post')
p.changes # => { 'title' => [nil, 'My Post'] }
```

Previously, this would only happen on objects that had been persisted.