### PR TITLE
Don't assume next_unscoped_key_column has a value

### DIFF
--- a/lib/cequel/record/record_set.rb
+++ b/lib/cequel/record/record_set.rb
@@ -819,7 +819,7 @@ module Cequel
       end
 
       def next_unscoped_key_name
-        next_unscoped_key_column.name
+        next_unscoped_key_column.try(:name)
       end
 
       def next_range_key_column


### PR DESCRIPTION
When writing specs we were receiving `undefined method 'name' for nil:NilClass` which was hiding the true problem.

Once applying the fix in this PR we were able to see the proper exception/problem, specifically (in our case):
`Can't scope key column <our column> without also scoping `