### PR TITLE
Added :foreign_key option to belongs_to association. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ gemfiles/*.gemfile.lock
 .ruby-version
 spec/log
 vendor/bundle
+.idea

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ The `auto` option for the `key` declaration means Cequel will initialize new
 records with a UUID already generated. This option is only valid for `:uuid` and
 `:timeuuid` key columns.
 
+The `belongs_to` association accepts a `:foreign_key` option which allows you to
+specify the attribute used as the partition key.
+
 Note that the `belongs_to` declaration must come *before* the `key` declaration.
 This is because `belongs_to` defines the
 [partition key](http://www.datastax.com/documentation/cql/3.0/webhelp/index.html#cql/ddl/../../cassandra/glossary/gloss_glossary.html#glossentry_dhv_s24_bk); the `id` column is

--- a/lib/cequel/record/associations.rb
+++ b/lib/cequel/record/associations.rb
@@ -110,13 +110,13 @@ module Cequel
           end
 
           key_options = options.extract!(:partition)
-          foreign_key_parts = [options.fetch(:foreign_key, [])].flatten
 
           self.parent_association =
             BelongsToAssociation.new(self, name.to_sym, options)
 
           parent_association.association_key_columns.each_with_index do |column, i|
-            foreign_key = foreign_key_parts[i].nil? ? "#{name}_#{column.name}" : foreign_key_parts[i]
+            foreign_key_parts = self.parent_association.foreign_keys
+            foreign_key = foreign_key_parts.any? ? foreign_key_parts[i] : "#{name}_#{column.name}"
             key foreign_key.to_sym, column.type, key_options
           end
           def_parent_association_accessors

--- a/lib/cequel/record/associations.rb
+++ b/lib/cequel/record/associations.rb
@@ -110,12 +110,13 @@ module Cequel
           end
 
           key_options = options.extract!(:partition)
+          foreign_key_parts = [options.fetch(:foreign_key, [])].flatten
 
           self.parent_association =
             BelongsToAssociation.new(self, name.to_sym, options)
 
-          parent_association.association_key_columns.each do |column|
-            foreign_key = options.fetch(:foreign_key, "#{name}_#{column.name}")
+          parent_association.association_key_columns.each_with_index do |column, i|
+            foreign_key = foreign_key_parts[i].nil? ? "#{name}_#{column.name}" : foreign_key_parts[i]
             key foreign_key.to_sym, column.type, key_options
           end
           def_parent_association_accessors

--- a/lib/cequel/record/associations.rb
+++ b/lib/cequel/record/associations.rb
@@ -108,14 +108,15 @@ module Cequel
                  "belongs_to association must be declared before declaring " \
                  "key(s)"
           end
-          
+
           key_options = options.extract!(:partition)
 
           self.parent_association =
             BelongsToAssociation.new(self, name.to_sym, options)
 
           parent_association.association_key_columns.each do |column|
-            key :"#{name}_#{column.name}", column.type, key_options
+            foreign_key = options.fetch(:foreign_key, "#{name}_#{column.name}")
+            key foreign_key.to_sym, column.type, key_options
           end
           def_parent_association_accessors
         end

--- a/lib/cequel/record/belongs_to_association.rb
+++ b/lib/cequel/record/belongs_to_association.rb
@@ -31,7 +31,7 @@ module Cequel
       # @api private
       #
       def initialize(owner_class, name, options = {})
-        options.assert_valid_keys(:class_name)
+        options.assert_valid_keys(:class_name, :foreign_key)
 
         @owner_class, @name = owner_class, name.to_sym
         @association_class_name =

--- a/lib/cequel/record/belongs_to_association.rb
+++ b/lib/cequel/record/belongs_to_association.rb
@@ -17,6 +17,8 @@ module Cequel
       attr_reader :name
       # @return [String] name of parent class
       attr_reader :association_class_name
+      # @return [Array] array of foreign key symbols
+      attr_reader :foreign_keys
 
       # @!attribute [r] association_key_columns
       #   @return [Array<Schema::Column>] key columns on the parent class
@@ -33,6 +35,7 @@ module Cequel
       def initialize(owner_class, name, options = {})
         options.assert_valid_keys(:class_name, :foreign_key)
 
+        @foreign_keys = Array(options.fetch(:foreign_key, [])).map { |x| x.to_sym }
         @owner_class, @name = owner_class, name.to_sym
         @association_class_name =
           options.fetch(:class_name, @name.to_s.classify)

--- a/spec/examples/record/associations_spec.rb
+++ b/spec/examples/record/associations_spec.rb
@@ -186,6 +186,31 @@ describe Cequel::Record::Associations do
       end
     end
 
+    context 'with foreign_key option' do
+      model :Parent do
+        key :parent_id, :uuid, auto: true
+        column :name, :text
+        has_many :children, class_name: 'Child'
+      end
+
+      model :Child do
+        belongs_to :parent, partition: true, foreign_key: :parent_id
+        key :child_id, :uuid, auto: true
+        column :name, :text
+      end
+
+      let(:parent) { Parent.new }
+      let(:child) { Child.new }
+
+      it "should add parent's keys as first keys" do
+        expect(Child.key_column_names.first(2)).to eq([:parent_id, :child_id])
+      end
+
+      it "should add parent's keys as partition keys" do
+        expect(Child.partition_key_column_names).to eq([:parent_id])
+      end
+    end
+
   end
 
   describe '::has_many' do

--- a/spec/examples/record/associations_spec.rb
+++ b/spec/examples/record/associations_spec.rb
@@ -194,13 +194,10 @@ describe Cequel::Record::Associations do
       end
 
       model :Child do
-        belongs_to :parent, partition: true, foreign_key: :parent_id
+        belongs_to :parent, partition: true, foreign_key: [:parent_id]
         key :child_id, :uuid, auto: true
         column :name, :text
       end
-
-      let(:parent) { Parent.new }
-      let(:child) { Child.new }
 
       it "should add parent's keys as first keys" do
         expect(Child.key_column_names.first(2)).to eq([:parent_id, :child_id])
@@ -208,6 +205,29 @@ describe Cequel::Record::Associations do
 
       it "should add parent's keys as partition keys" do
         expect(Child.partition_key_column_names).to eq([:parent_id])
+      end
+
+      context 'with multiple foreign_keys' do
+        model :Foo do
+          key :account_id, :uuid, auto: true
+          key :parent_id, :uuid, auto: true
+          column :name, :text
+          has_many :children, class_name: 'Child'
+        end
+
+        model :Bar do
+          belongs_to :foo, partition: true, foreign_key: [:account_id, :parent_id]
+          key :child_id, :uuid, auto: true
+          column :name, :text
+        end
+
+        it "should add parent's keys as first keys" do
+          expect(Bar.key_column_names).to eq([:account_id, :parent_id, :child_id])
+        end
+
+        it "should add parent's keys as partition keys" do
+          expect(Bar.partition_key_column_names).to eq([:account_id, :parent_id])
+        end
       end
     end
 


### PR DESCRIPTION
This PR adds a `:foreign_key` option to the `belongs_to` association.

This works well for: 
* Using cequel on schemas that do not follow a rails relational convention of naming or, that use a consistent naming throughout.
* Tables that have composite partition keys where parts are outside of your own domain i.e. `account_id` where `account_id` is used in many tables.  

Given the existing tables:
```sql
Create table parent (
  account_id uuid,
  parent_id uuid,
  name text,
  PRIMARY KEY (account_id, parent_id)
);

Create table child (
  parent_id uuid,
  child_id uuid,
  name text,
  PRIMARY KEY ((parent_id), child_id)
);
```

Example:
```ruby
class Parent
  include Cequel::Record
  key :account_id, :uuid, partition: true
  key :parent_id, :uuid, partition: true
  column :name, :text
end

class Child
  include Cequel::Record
  belongs_to :parent, foreign_key: [:account_id, :parent_id]
  key :child_id, :uuid, auto: true
  column :name, :text
end
```