### PR TITLE
NewRelic instrumentation

### DIFF
--- a/lib/cequel/metal/new_relic_instrumentation.rb
+++ b/lib/cequel/metal/new_relic_instrumentation.rb
@@ -15,7 +15,7 @@ module Cequel
 
       define_method :execute_with_consistency_with_newrelic do |statement, bind_vars, consistency|
         callback = Proc.new do |result, scoped_metric, elapsed|
-          NewRelic::Agent::Datastores.notice_sql(statement, scoped_metric, elapsed)
+          NewRelic::Agent::Datastores.notice_statement(statement, elapsed)
         end
 
         statement_words = statement.split

--- a/lib/cequel/metal/new_relic_instrumentation.rb
+++ b/lib/cequel/metal/new_relic_instrumentation.rb
@@ -19,16 +19,16 @@ module Cequel
         end
 
         statement_words = statement.split
-        operation = statement_words.first
+        operation = statement_words.first.downcase
         table = nil
         case operation
-        when "BEGIN"
-          operation = "BATCH"
-        when "SELECT"
+        when "begin"
+          operation = "batch"
+        when "select"
           table = statement_words.at(statement_words.index("FROM") + 1)
-        when "INSERT"
+        when "insert"
           table = statement_words[2]
-        when "UPDATE"
+        when "update"
           table = statement_words[1]
         end
 

--- a/lib/cequel/metal/new_relic_instrumentation.rb
+++ b/lib/cequel/metal/new_relic_instrumentation.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 begin
-  require 'new_relic/agent/method_tracer'
+  require 'new_relic/agent/datastores'
 rescue LoadError => e
   fail LoadError, "Can't use NewRelic instrumentation without NewRelic gem"
 end
@@ -13,12 +13,32 @@ module Cequel
     module NewRelicInstrumentation
       extend ActiveSupport::Concern
 
-      included do
-        include NewRelic::Agent::MethodTracer
+      define_method :execute_with_consistency_with_newrelic do |statement, bind_vars, consistency|
+        callback = Proc.new do |result, scoped_metric, elapsed|
+          NewRelic::Agent::Datastores.notice_sql(statement, scoped_metric, elapsed)
+        end
 
-        add_method_tracer :execute_with_consistency,
-                          'Database/Cassandra/#{args[0][/^[A-Z ]*[A-Z]/]' \
-                          '.sub(/ FROM$/, \'\')}'
+        statement_words = statement.split
+        operation = statement_words.first
+        table = nil
+        case operation
+        when "BEGIN"
+          operation = "BATCH"
+        when "SELECT"
+          table = statement_words.at(statement_words.index("FROM") + 1)
+        when "INSERT"
+          table = statement_words[2]
+        when "UPDATE"
+          table = statement_words[1]
+        end
+
+        NewRelic::Agent::Datastores.wrap("Cassandra", operation, table, callback) do
+          execute_with_consistency_without_newrelic(statement, bind_vars, consistency)
+        end
+      end
+
+      included do
+        alias_method_chain :execute_with_consistency, :newrelic
       end
     end
   end

--- a/lib/cequel/record/railtie.rb
+++ b/lib/cequel/record/railtie.rb
@@ -22,9 +22,9 @@ module Cequel
       end
 
       initializer "cequel.add_new_relic" do
-        if configuration.fetch(:newrelic_enabled, true)
+        if configuration.fetch(:newrelic, true)
           begin
-            require 'new_relic/agent/method_tracer'
+            require 'new_relic/agent/datastores'
           rescue LoadError => e
             Rails.logger.debug(
               "New Relic not installed; skipping New Relic integration")


### PR DESCRIPTION
Instrumentation thru `NewRelic::Agent::Datastores` to make Cassandra visible as database.
Statistics are grouped by statement type + table name.
CQL visible only for slow queries.

Fixed config param name. (`newrelic` vs `newrelic_enabled`)