### PR TITLE
switch instrumentation from execute_with_consistency to execute_with_options

### DIFF
--- a/lib/cequel/metal/new_relic_instrumentation.rb
+++ b/lib/cequel/metal/new_relic_instrumentation.rb
@@ -1,7 +1,7 @@
 # -*- encoding : utf-8 -*-
 begin
   require 'new_relic/agent/datastores'
-rescue LoadError => e
+rescue LoadError
   fail LoadError, "Can't use NewRelic instrumentation without NewRelic gem"
 end
 
@@ -13,7 +13,7 @@ module Cequel
     module NewRelicInstrumentation
       extend ActiveSupport::Concern
 
-      define_method :execute_with_consistency_with_newrelic do |statement, bind_vars, consistency|
+      define_method :execute_with_options_with_newrelic do |statement, bind_vars, options|
         callback = Proc.new do |result, scoped_metric, elapsed|
           NewRelic::Agent::Datastores.notice_statement(statement, elapsed)
         end
@@ -33,12 +33,13 @@ module Cequel
         end
 
         NewRelic::Agent::Datastores.wrap("Cassandra", operation, table, callback) do
-          execute_with_consistency_without_newrelic(statement, bind_vars, consistency)
+          execute_with_options_without_newrelic(statement, bind_vars, options)
         end
       end
 
+
       included do
-        alias_method_chain :execute_with_consistency, :newrelic
+        alias_method_chain :execute_with_options, :newrelic
       end
     end
   end


### PR DESCRIPTION
I hadn't ever gotten the new relic instrumentation to work, but I attributed it to configuration issues.  After diving in, I found that the changes I made a few months ago to support pagination may have broken the usefulness of instrumenting `execute_with_consistency` since it is now only used when doing batch queries.

Since `execute_with_consistency` calls `execute_with_options`, I thought it would make sense to change the instrumented method.  Trying it out locally, I was able to start seeing metrics and transaction segments for Cequel, as I never had before.