### PR TITLE
Added client_compression setting and pass it to driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ gemfiles/*.gemfile.lock
 .ruby-version
 spec/log
 vendor/bundle
+.idea

--- a/README.md
+++ b/README.md
@@ -382,6 +382,20 @@ Post.consistency(:one).find_each { |post| puts post.title }
 
 Both read and write consistency default to `QUORUM`.
 
+### Compression ###
+
+Cassandra supports [frame compression](http://datastax.github.io/ruby-driver/features/#compression),
+which can give you a performance boost if your requests or responses are big. To enable it you can 
+specify `client_compression` to use in cequel.yaml.
+
+```yaml
+development:
+  host: '127.0.0.1'
+  port: 9042
+  keyspace: Blog
+  client_compression: :lz4
+```
+
 ### ActiveModel Support ###
 
 Cequel supports ActiveModel functionality, such as callbacks, validations,

--- a/lib/cequel/metal/keyspace.rb
+++ b/lib/cequel/metal/keyspace.rb
@@ -32,6 +32,8 @@ module Cequel
       attr_reader :credentials
       # @return [Hash] SSL Configuration options
       attr_reader :ssl_config
+      # @return [Symbol] The client compression option
+      attr_reader :client_compression
 
       #
       # @!method write(statement, *bind_vars)
@@ -139,6 +141,7 @@ module Cequel
 
         @name = configuration[:keyspace]
         @default_consistency = configuration[:default_consistency].try(:to_sym)
+        @client_compression = configuration[:client_compression].try(:to_sym)
 
         # reset the connections
         clear_active_connections!
@@ -284,6 +287,7 @@ module Cequel
         {hosts: hosts, port: port}.tap do |options|
           options.merge!(credentials) if credentials
           options.merge!(ssl_config) if ssl_config
+          options.merge!(compression: client_compression) if client_compression
         end
       end
 

--- a/spec/examples/metal/keyspace_spec.rb
+++ b/spec/examples/metal/keyspace_spec.rb
@@ -104,6 +104,18 @@ describe Cequel::Metal::Keyspace do
     end
   end
 
+  describe "#client_compression" do
+    let(:client_compression) { :lz4 }
+    let(:connect) do
+      Cequel.connect host: Cequel::SpecSupport::Helpers.host,
+          port: Cequel::SpecSupport::Helpers.port,
+          client_compression: client_compression
+    end
+    it "client compression settings get extracted correctly for sending to cluster" do
+      expect(connect.client_compression).to eq client_compression
+    end
+  end
+
   describe "#execute" do
     let(:statement) { "SELECT id FROM posts" }
 


### PR DESCRIPTION
Adds cassandra client compression to Cequel gem. 

This PR adds a new setting to the config to allow compression. It basically just passes it along to the Cassandra driver. 

See: http://datastax.github.io/ruby-driver/features/#compression for more info.