### PR TITLE
Support blob values

### DIFF
--- a/lib/cequel/metal/keyspace.rb
+++ b/lib/cequel/metal/keyspace.rb
@@ -196,7 +196,7 @@ module Cequel
         retries = max_retries
         log('CQL', statement, *bind_vars) do
           begin
-            client.execute(sanitize(statement, bind_vars), options)
+            client.execute(statement, options.merge(arguments: bind_vars))
           rescue Cassandra::Errors::NoHostsAvailable,
                  Ione::Io::ConnectionError => e
             clear_active_connections!
@@ -257,7 +257,7 @@ module Cequel
         CQL
 
         log('CQL', statement, [name]) do
-          client_without_keyspace.execute(sanitize(statement, [name])).any?
+          client_without_keyspace.execute(statement, arguments: [name]).any?
         end
       end
 

--- a/spec/examples/record/persistence_spec.rb
+++ b/spec/examples/record/persistence_spec.rb
@@ -15,6 +15,7 @@ describe Cequel::Record::Persistence do
     column :title, :text
     column :body, :text
     column :author_id, :uuid
+    column :picture, :blob
   end
 
   context 'simple keys' do
@@ -262,12 +263,36 @@ describe Cequel::Record::Persistence do
         where(:blog_subdomain => 'cassandra', :permalink => 'cequel').first
     end
 
+    let(:picture) do
+      <<-EOP
+      * ***                                                 ***
+    *  ****  *                                               ***
+   *  *  ****                                                 **
+  *  **   **                                                  **
+ *  ***                     ****    **   ****                 **
+**   **           ***      * ***  *  **    ***  *    ***      **
+**   **          * ***    *   ****   **     ****    * ***     **
+**   **         *   ***  **    **    **      **    *   ***    **
+**   **        **    *** **    **    **      **   **    ***   **
+**   **        ********  **    **    **      **   ********    **
+ **  **        *******   **    **    **      **   *******     **
+  ** *      *  **        **    **    **      **   **          **
+   ***     *   ****    *  *******     ******* **  ****    *   **
+    *******     *******    ******      *****   **  *******    *** *
+      ***        *****         **                   *****      ***
+                               **
+                               **
+                                **
+      EOP
+    end
+
     let!(:post) do
       Post.new do |post|
         post.blog_subdomain = 'cassandra'
         post.permalink = 'cequel'
         post.title = 'Cequel'
         post.body = 'A Ruby ORM for Cassandra 1.2'
+        post.picture = picture
       end.tap(&:save)
     end
 
@@ -275,6 +300,7 @@ describe Cequel::Record::Persistence do
       context 'on create' do
         it 'should save row to database' do
           expect(subject[:title]).to eq('Cequel')
+          expect(subject[:picture]).to eq(picture)
         end
 
         it 'should mark row persisted' do


### PR DESCRIPTION
Blob values weren't supported correctly due to cequel doing its own statement sanitization (skipping hex encoding). Since cassandra-driver supports statements with arguments now, use that instead.