### PR TITLE
limit is not applied to the collection before it is counted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 * drop support for JRuby 1.7
+* Dropped support for count, length, and size as it results in unbounded run times and memory usage
+  ([PR 313](https://github.com/cequel/cequel/pull/313))
 
 ## 1.10.0
 

--- a/README.md
+++ b/README.md
@@ -534,6 +534,14 @@ essentially the same thing: both simply persist the given column data at the
 given key(s). So, you may think you are creating a new record, but in fact
 you're overwriting data at an existing record:
 
+#### Counting ####
+
+Counting is not the same as in a RDB, as it can have a much longer runtime and
+can put unexpected load on your cluster. As a result Cequel does not support
+this feature. It is still possible to execute raw cql to get the counts, should
+you require this functionality.
+`MyModel.connection.execute('select count(*) from table_name;').first['count']`
+
 ``` ruby
 # I'm just creating a blog here.
 blog1 = Blog.create!(

--- a/lib/cequel/metal/data_set.rb
+++ b/lib/cequel/metal/data_set.rb
@@ -615,7 +615,12 @@ module Cequel
       # @return [Fixnum] the number of rows in this data set
       #
       def count
-        execute_cql(*count_cql).first['count']
+        actual_count = execute_cql(*count_cql).first['count']
+        if row_limit
+          [actual_count, row_limit].min
+        else
+          actual_count
+        end
       end
 
       #
@@ -637,8 +642,7 @@ module Cequel
       def count_cql
         Statement.new
           .append("SELECT COUNT(*) FROM #{table_name}")
-          .append(*row_specifications_cql)
-          .append(limit_cql).args
+          .append(*row_specifications_cql).args
       end
 
       #

--- a/lib/cequel/metal/data_set.rb
+++ b/lib/cequel/metal/data_set.rb
@@ -611,17 +611,13 @@ module Cequel
         Row.from_result_row(row)
       end
 
-      #
-      # @return [Fixnum] the number of rows in this data set
-      #
+      # @raise [DangerousQueryError] to prevent loading the entire record set
+      #   to be counted
       def count
-        actual_count = execute_cql(*count_cql).first['count']
-        if row_limit
-          [actual_count, row_limit].min
-        else
-          actual_count
-        end
+        raise Cequel::Record::DangerousQueryError.new
       end
+      alias_method :length, :count
+      alias_method :size, :count
 
       #
       # @return [String] CQL `SELECT` statement encoding this data set's scope.
@@ -634,15 +630,6 @@ module Cequel
           .append(sort_order_cql)
           .append(limit_cql)
           .args
-      end
-
-      #
-      # @return [String] CQL statement to get count of rows in this data set
-      #
-      def count_cql
-        Statement.new
-          .append("SELECT COUNT(*) FROM #{table_name}")
-          .append(*row_specifications_cql).args
       end
 
       #

--- a/lib/cequel/record/association_collection.rb
+++ b/lib/cequel/record/association_collection.rb
@@ -50,41 +50,14 @@ module Cequel
       end
 
       #
-      # @!method count
-      #   Get the count of child records stored in the database. This method
-      #   will always query Cassandra, even if the records are loaded in
-      #   memory.
+      # @raise [DangerousQueryError] to prevent loading the entire record set
+      #   to be counted
       #
-      #   @return [Integer] number of child records in the database
-      #   @see #size
-      #   @see #length
-      #
-      def_delegator :record_set, :count
-
-      #
-      # @!method length
-      #   The number of child instances in the in-memory collection. If the
-      #   records are not loaded in memory, they will be loaded and then
-      #   counted.
-      #
-      #   @return [Integer] length of the loaded record collection in memory
-      #   @see #size
-      #   @see #count
-      #
-      def_delegator :entries, :length
-
-      #
-      # Get the size of the child collection. If the records are loaded in
-      # memory from a previous operation, count the length of the array in
-      # memory. If the collection is unloaded, perform a `COUNT` query.
-      #
-      # @return [Integer] size of the child collection
-      # @see #length
-      # @see #count
-      #
-      def size
-        loaded? ? length : count
+      def count
+        raise Cequel::Record::DangerousQueryError.new
       end
+      alias_method :length, :count
+      alias_method :size, :count
 
       #
       # @return [Boolean] true if this collection's records are loaded in

--- a/lib/cequel/record/errors.rb
+++ b/lib/cequel/record/errors.rb
@@ -45,6 +45,12 @@ module Cequel
     IllegalQuery = Class.new(StandardError)
 
     #
+    # Raised when attempting to perform a query that has detrimental effects.
+    # Typically when trying to count records.
+    #
+    DangerousQueryError = Class.new(StandardError)
+
+    #
     # Raised when attempting to persist a Cequel::Record without defining all
     # primary key columns
     #

--- a/lib/cequel/record/record_set.rb
+++ b/lib/cequel/record/record_set.rb
@@ -537,11 +537,10 @@ module Cequel
         end
       end
 
-      #
-      # @return [Integer] the total number of records in this record set
-      #
+      # @raise [DangerousQueryError] to prevent loading the entire record set
+      #   to be counted
       def count
-        data_set.count
+        raise Cequel::Record::DangerousQueryError.new
       end
       alias_method :length, :count
       alias_method :size, :count

--- a/spec/examples/metal/data_set_spec.rb
+++ b/spec/examples/metal/data_set_spec.rb
@@ -594,10 +594,6 @@ describe Cequel::Metal::DataSet do
       expect_query_with_consistency(/SELECT/, :one) { data_set.to_a }
     end
 
-    it 'should issue COUNT with scoped consistency' do
-      expect_query_with_consistency(/SELECT.*COUNT/, :one) { data_set.count }
-    end
-
     it 'should issue INSERT with scoped consistency' do
       expect_query_with_consistency(/INSERT/, :one) do
         data_set.insert(row_keys)
@@ -632,10 +628,6 @@ describe Cequel::Metal::DataSet do
       expect_query_with_consistency(/SELECT/, :all) { data_set.to_a }
     end
 
-    it 'should issue COUNT with default consistency' do
-      expect_query_with_consistency(/SELECT.*COUNT/, :all) { data_set.count }
-    end
-
     it 'should issue INSERT with default consistency' do
       expect_query_with_consistency(/INSERT/, :all) do
         data_set.insert(row_keys)
@@ -667,10 +659,6 @@ describe Cequel::Metal::DataSet do
     it 'should issue SELECT with scoped page size' do
       expect_query_with_options(/SELECT/, :page_size => 1) { data_set.to_a }
     end
-
-    it 'should issue COUNT with scoped page size' do
-      expect_query_with_options(/SELECT.*COUNT/, :page_size => 1) { data_set.count }
-    end
   end
 
   describe '#paging_state' do
@@ -678,10 +666,6 @@ describe Cequel::Metal::DataSet do
 
     it 'should issue SELECT with scoped paging state' do
       expect_query_with_options(/SELECT/, :paging_state => nil) { data_set.to_a }
-    end
-
-    it 'should issue COUNT with scoped paging state' do
-      expect_query_with_options(/SELECT.*COUNT/, :paging_state => nil) { data_set.count }
     end
   end
 
@@ -735,22 +719,16 @@ describe Cequel::Metal::DataSet do
       end
     end
 
-    it 'should run a count query and return count' do
-      expect(cequel[:posts].count).to eq(4)
+    it 'should raise DangerousQueryError when attempting to count' do
+      expect{ cequel[:posts].count }.to raise_error(Cequel::Record::DangerousQueryError)
     end
 
-    it 'should use where clause if specified' do
-      expect(cequel[:posts].where(row_keys.merge(permalink: 'post-1')).
-        count).to eq(1)
+    it 'should raise DangerousQueryError when attempting to access size' do
+      expect{ cequel[:posts].size }.to raise_error(Cequel::Record::DangerousQueryError)
     end
 
-    it 'should use limit if specified' do
-      expect(cequel[:posts].limit(2).count).to eq(2)
-    end
-
-    it 'should return the minimum of the requested limit and the actual record count' do
-      expect(cequel[:posts].limit(5).count).to eq(4)
+    it 'should raise DangerousQueryError when attempting to access length' do
+      expect{ cequel[:posts].length }.to raise_error(Cequel::Record::DangerousQueryError)
     end
   end
-
 end

--- a/spec/examples/metal/data_set_spec.rb
+++ b/spec/examples/metal/data_set_spec.rb
@@ -747,6 +747,10 @@ describe Cequel::Metal::DataSet do
     it 'should use limit if specified' do
       expect(cequel[:posts].limit(2).count).to eq(2)
     end
+
+    it 'should return the minimum of the requested limit and the actual record count' do
+      expect(cequel[:posts].limit(5).count).to eq(4)
+    end
   end
 
 end

--- a/spec/examples/metal/keyspace_spec.rb
+++ b/spec/examples/metal/keyspace_spec.rb
@@ -35,9 +35,9 @@ describe Cequel::Metal::Keyspace do
     it 'should auto-apply if option given' do
       cequel.batch(auto_apply: 2) do
         cequel[:posts].insert(id: 1, title: 'One')
-        expect(cequel[:posts].count).to be_zero
+        expect(cequel[:posts].to_a.count).to be_zero
         cequel[:posts].insert(id: 2, title: 'Two')
-        expect(cequel[:posts].count).to be(2)
+        expect(cequel[:posts].to_a.count).to be(2)
       end
     end
 

--- a/spec/examples/record/associations_spec.rb
+++ b/spec/examples/record/associations_spec.rb
@@ -297,26 +297,16 @@ describe Cequel::Record::Associations do
       expect(blog.posts.first.title).to eq('Post 0')
     end
 
-    it 'should always query the database for #count' do
-      blog.posts.entries
-      posts.first.destroy
-      expect(blog.posts.count).to eq(2)
+    it 'should raise DangerousQueryError for #count' do
+      expect{ blog.posts.count }.to raise_error(Cequel::Record::DangerousQueryError)
     end
 
-    it 'should always load the records for #length' do
-      expect(blog.posts.length).to eq(3)
-      expect(blog.posts).to be_loaded
+    it 'should raise DangerousQueryError for #length' do
+      expect{ blog.posts.length }.to raise_error(Cequel::Record::DangerousQueryError)
     end
 
-    it 'should count from database for #size if unloaded' do
-      expect(blog.posts.size).to eq(3)
-      expect(blog.posts).not_to be_loaded
-    end
-
-    it 'should count records in memory for #size if loaded' do
-      blog.posts.entries
-      disallow_queries!
-      expect(blog.posts.size).to eq(3)
+    it 'should raise DangerousQueryError for #size' do
+      expect{ blog.posts.size }.to raise_error(Cequel::Record::DangerousQueryError)
     end
 
     it "does not allow invalid :dependent options" do
@@ -350,7 +340,7 @@ describe Cequel::Record::Associations do
       it "deletes all children when destroying the parent" do
         expect {
           post_with_comments.destroy
-        }.to change { Comment.count }.by(-2)
+        }.to change { Comment.all.to_a.count }.by(-2)
       end
 
       it "executes :destroy callbacks on the children" do
@@ -375,7 +365,7 @@ describe Cequel::Record::Associations do
       it "deletes all children when destroying the parent" do
         expect {
           post_with_attachments.destroy
-        }.to change { Attachment.count }.by(-2)
+        }.to change { Attachment.all.to_a.count }.by(-2)
       end
 
       it "does not execute :destroy callbacks on the children" do

--- a/spec/examples/record/record_set_spec.rb
+++ b/spec/examples/record/record_set_spec.rb
@@ -676,6 +676,10 @@ describe Cequel::Record::RecordSet do
     it 'should return the number of records requested' do
       expect(Blog.limit(2).length).to be(2)
     end
+
+    it 'should return the minimum of the requested limit and the actual record count' do
+      expect(Blog.limit(5).length).to be(3)
+    end
   end
 
   describe '#select' do

--- a/spec/examples/record/record_set_spec.rb
+++ b/spec/examples/record/record_set_spec.rb
@@ -674,11 +674,11 @@ describe Cequel::Record::RecordSet do
     let(:records) { blogs }
 
     it 'should return the number of records requested' do
-      expect(Blog.limit(2).length).to be(2)
+      expect(Blog.limit(2).to_a.length).to be(2)
     end
 
     it 'should return the minimum of the requested limit and the actual record count' do
-      expect(Blog.limit(5).length).to be(3)
+      expect(Blog.limit(5).to_a.length).to be(3)
     end
   end
 
@@ -851,10 +851,34 @@ describe Cequel::Record::RecordSet do
   end
 
   describe '#count' do
-    let(:records) { blogs }
+    let(:records) { posts }
 
-    it 'should count records' do
-      expect(Blog.count).to eq(3)
+    context 'without scoping' do
+      it 'should raise DangerousQueryError when attempting to count' do
+        expect{ Post.count }.to raise_error(Cequel::Record::DangerousQueryError)
+      end
+
+      it 'should raise DangerousQueryError when attempting to access size' do
+        expect{ Post.size }.to raise_error(Cequel::Record::DangerousQueryError)
+      end
+
+      it 'should raise DangerousQueryError when attempting to access length' do
+        expect{ Post.length }.to raise_error(Cequel::Record::DangerousQueryError)
+      end
+    end
+
+    context 'with scoping' do
+      it 'should raise DangerousQueryError when attempting to count' do
+        expect{ Post['postgres'].count }.to raise_error(Cequel::Record::DangerousQueryError)
+      end
+
+      it 'should raise DangerousQueryError when attempting to access size' do
+        expect{ Post['postgres'].size }.to raise_error(Cequel::Record::DangerousQueryError)
+      end
+
+      it 'should raise DangerousQueryError when attempting to access length' do
+        expect{ Post['postgres'].length }.to raise_error(Cequel::Record::DangerousQueryError)
+      end
     end
   end
 
@@ -899,13 +923,13 @@ describe Cequel::Record::RecordSet do
 
     it 'should be able to delete with no scoping' do
       Post.delete_all
-      expect(Post.count).to be_zero
+      expect(Post.first).to be_nil
     end
 
     it 'should be able to delete with scoping' do
       Post['postgres'].delete_all
-      expect(Post['postgres'].count).to be_zero
-      expect(Post['cassandra'].count).to eq(cassandra_posts.length)
+      expect(Post['postgres'].first).to be_nil
+      expect(Post['cassandra'].to_a.count).to eq(cassandra_posts.length)
     end
 
     it 'should be able to delete fully specified collection' do
@@ -920,13 +944,13 @@ describe Cequel::Record::RecordSet do
 
     it 'should be able to delete with no scoping' do
       Post.destroy_all
-      expect(Post.count).to be_zero
+      expect(Post.first).to be_nil
     end
 
     it 'should be able to delete with scoping' do
       Post['postgres'].destroy_all
-      expect(Post['postgres'].count).to be_zero
-      expect(Post['cassandra'].count).to eq(cassandra_posts.length)
+      expect(Post['postgres'].first).to be_nil
+      expect(Post['cassandra'].to_a.count).to eq(cassandra_posts.length)
     end
 
     it 'should be able to delete fully specified collection' do
@@ -978,5 +1002,4 @@ describe Cequel::Record::RecordSet do
         .to yield_successive_args *blog_1_views
     end
   end
-
 end


### PR DESCRIPTION
Ive been working on upgrading to cassandra 3 and came across a difference in the way `LIMIT` functions. In older versions of cassandra it seems that the limit is applied to the data set before it is counted. In later versions it applies the limit to the number of rows that were returned, which is always 1.

I havent tested this out on the different vagrant images to see when this behaviour change occurred, but it is somewhere between `Cassandra 2.1.13.1131` and `Cassandra 3.0.7.1159`

/cc @orenmazor