### PR TITLE
Port gem to Cassandra 3

### DIFF
--- a/cequel.gemspec
+++ b/cequel.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
     'Ilya Bazylchuk', 'Dan Cardamore', 'Kei Kusakari', 'Oleh Novosad',
     'John Smart', 'Angelo Lakra', 'Olivier Lance', 'Tomohiro Nishimura',
     'Masaki Takahashi', 'G Gordon Worley III', 'Clark Bremer', 'Tamara Temple',
-    'Long On', 'Lucas Mundim'
+    'Long On', 'Lucas Mundim', 'Eric Urban'
   ]
   s.homepage = "https://github.com/cequel/cequel"
   s.email = 'mat.a.brown@gmail.com'
@@ -27,8 +27,8 @@ DESC
   s.has_rdoc = true
   s.extra_rdoc_files = 'README.md'
   s.required_ruby_version = '>= 2.0'
-  s.add_runtime_dependency 'activemodel', '~> 4.0'
-  s.add_runtime_dependency 'cassandra-driver', '~> 2.0'
+  s.add_runtime_dependency 'activemodel', '~> 4.2'
+  s.add_runtime_dependency 'cassandra-driver', '~> 3.0.3'
   s.add_development_dependency 'appraisal', '~> 1.0'
   s.add_development_dependency 'wwtd', '~> 0.5'
   s.add_development_dependency 'rake', '~> 10.1'

--- a/lib/cequel/metal/keyspace.rb
+++ b/lib/cequel/metal/keyspace.rb
@@ -34,6 +34,8 @@ module Cequel
       attr_reader :ssl_config
       # @return [Symbol] The client compression option
       attr_reader :client_compression
+      # @return [Hash] A hash of configuration options passed to Cassandra.cluster, with absolute precedence 
+      attr_reader :cluster_options
 
       #
       # @!method write(statement, *bind_vars)
@@ -138,6 +140,7 @@ module Cequel
         @max_retries  = extract_max_retries(configuration)
         @retry_delay  = extract_retry_delay(configuration)
         @ssl_config = extract_ssl_config(configuration)
+        @cluster_options = configuration[:cluster_options]
 
         @name = configuration[:keyspace]
         @default_consistency = configuration[:default_consistency].try(:to_sym)
@@ -284,6 +287,7 @@ module Cequel
           options.merge!(credentials) if credentials
           options.merge!(ssl_config) if ssl_config
           options.merge!(compression: client_compression) if client_compression
+          options.merge!(cluster_options) if cluster_options
         end
       end
 

--- a/lib/cequel/metal/keyspace.rb
+++ b/lib/cequel/metal/keyspace.rb
@@ -250,12 +250,8 @@ module Cequel
 
       # @return [Boolean] true if the keyspace exists
       def exists?
-        statement = <<-CQL
-          SELECT keyspace_name
-          FROM system.schema_keyspaces
-          WHERE keyspace_name = ?
-        CQL
-
+        statement = Cassandra::Cluster::Schema::Fetchers::V3_0_x::SELECT_KEYSPACE 
+        
         log('CQL', statement, [name]) do
           client_without_keyspace.execute(sanitize(statement, [name])).any?
         end

--- a/lib/cequel/metal/keyspace.rb
+++ b/lib/cequel/metal/keyspace.rb
@@ -301,7 +301,7 @@ module Cequel
 
       def extract_hosts_and_port(configuration)
         hosts, ports = [], Set[]
-        ports << configuration[:port] if configuration.key?(:port)
+        ports << configuration[:port] if configuration[:port].present?
         host_or_hosts =
           configuration.fetch(:host, configuration.fetch(:hosts, '127.0.0.1'))
         Array.wrap(host_or_hosts).each do |host_port|
@@ -311,16 +311,19 @@ module Cequel
             warn "Specifying a hostname as host:port is deprecated. Specify " \
                  "only the host IP or hostname in :hosts, and specify a " \
                  "port for all nodes using the :port option."
-            ports << port.to_i
+            ports << port
           end
         end
 
         if ports.size > 1
           fail ArgumentError, "All Cassandra nodes must listen on the same " \
                "port; specified multiple ports #{ports.join(', ')}"
+        elsif ports.size != 1
+          fail ArgumentError, "Port for cassandra nodes not specified"
         end
+        
 
-        [hosts, ports.first || 9042]
+        [hosts, Integer(ports.first) || 9042]
       end
 
       def extract_credentials(configuration)

--- a/lib/cequel/metal/keyspace.rb
+++ b/lib/cequel/metal/keyspace.rb
@@ -323,7 +323,7 @@ module Cequel
         end
         
 
-        [hosts, Integer(ports.first) || 9042]
+        [hosts, Integer(ports.first || 9042)]
       end
 
       def extract_credentials(configuration)

--- a/lib/cequel/record/collection.rb
+++ b/lib/cequel/record/collection.rb
@@ -332,7 +332,7 @@ module Cequel
       #
       def unshift(*objects)
         objects.map!(&method(:cast_element))
-        to_update { updater.list_prepend(column_name, objects.reverse) }
+        to_update { updater.list_prepend(column_name, objects) }
         to_modify { super }
       end
       alias_method :prepend, :unshift

--- a/lib/cequel/record/schema.rb
+++ b/lib/cequel/record/schema.rb
@@ -118,7 +118,12 @@ module Cequel
 
         def column(name, type, options = {})
           super
-          table_schema.add_data_column(name, type, options[:index])
+          
+          index_name = options[:index]
+          # If passed a boolean, autogenerate the index name
+          index_name = :"#{name}_#{name}_idx" if index_name == true
+          
+          table_schema.add_data_column(name, type, index: index_name)
         end
 
         def list(name, type, options = {})

--- a/lib/cequel/schema/create_table_dsl.rb
+++ b/lib/cequel/schema/create_table_dsl.rb
@@ -48,7 +48,13 @@ module Cequel
       # @!method column(name, type, options = {})
       #   (see Cequel::Schema::Table#add_data_column)
       #
-      def_delegator :@table, :add_data_column, :column
+      def column(name, type, options = {})
+        index_name = options[:index]
+        # If passed a boolean, autogenerate the index name
+        index_name = :"#{name}_#{name}_idx" if index_name == true
+        @table.add_data_column(name, type, index: index_name)
+      end 
+        
 
       #
       # @!method list(name, type)

--- a/lib/cequel/schema/table.rb
+++ b/lib/cequel/schema/table.rb
@@ -33,6 +33,7 @@ module Cequel
       # @return [Boolean] `true` if this table is configured with compact
       #   storage
       attr_writer :compact_storage
+      attr_writer :dense
 
       #
       # @param name [Symbol] the name of the table
@@ -278,6 +279,13 @@ module Cequel
       #
       def compact_storage?
         !!@compact_storage
+      end
+      
+      #
+      # @return [Boolean] `true` if this table uses dense storage
+      #
+      def dense?
+        !!@dense
       end
 
       protected

--- a/lib/cequel/schema/table.rb
+++ b/lib/cequel/schema/table.rb
@@ -12,7 +12,6 @@ module Cequel
       STORAGE_PROPERTIES = %w(
         bloom_filter_fp_chance caching comment compaction compression
         dclocal_read_repair_chance gc_grace_seconds read_repair_chance
-        replicate_on_write
       )
 
       # @return [Symbol] the name of the table

--- a/lib/cequel/schema/table.rb
+++ b/lib/cequel/schema/table.rb
@@ -12,6 +12,7 @@ module Cequel
       STORAGE_PROPERTIES = %w(
         bloom_filter_fp_chance caching comment compaction compression
         dclocal_read_repair_chance gc_grace_seconds read_repair_chance
+        crc_check_chance
       )
 
       # @return [Symbol] the name of the table

--- a/lib/cequel/schema/table.rb
+++ b/lib/cequel/schema/table.rb
@@ -99,15 +99,14 @@ module Cequel
       # @param name [Symbol] name of the column
       # @param type [Type] type for the column
       # @param options [Options] options for the column
-      # @option options [Boolean,Symbol] :index (nil) name of a secondary index
-      #   to apply to the column, or `true` to infer an index name by
-      #   convention
+      # @option options [Symbol] :index (nil) name of a secondary index
+      #   to apply to the column
       # @return [void]
       #
       def add_data_column(name, type, options = {})
         options = {index: options} unless options.is_a?(Hash)
         index_name = options[:index]
-        index_name = :"#{@name}_#{name}_idx" if index_name == true
+        
         DataColumn.new(name, type(type), index_name)
           .tap { |column| @data_columns << add_column(column) }
       end

--- a/lib/cequel/schema/table_property.rb
+++ b/lib/cequel/schema/table_property.rb
@@ -17,6 +17,10 @@ module Cequel
       # @api private
       #
       def self.build(name, value)
+        if value.is_a?(Hash)
+          value = value.symbolize_keys 
+        end
+        
         clazz =
           case name.to_sym
           when :compaction then CompactionProperty
@@ -98,9 +102,9 @@ module Cequel
         case key
         when :class
           value.sub(/^org\.apache\.cassandra\.db\.compaction\./, '')
-        when :bucket_high, :bucket_low, :tombstone_threshold then value.to_f
+        when :bucket_high, :bucket_low, :tombstone_threshold then Kernel.Float(value)
         when :max_threshold, :min_threshold, :min_sstable_size,
-          :sstable_size_in_mb, :tombstone_compaction_interval then value.to_i
+          :sstable_size_in_mb, :tombstone_compaction_interval then Kernel.Integer(value)
         else value.to_s
         end
       end
@@ -114,10 +118,10 @@ module Cequel
 
       def normalize_map_property(key, value)
         case key
-        when :sstable_compression
+        when :class
           value.sub(/^org\.apache\.cassandra\.io\.compress\./, '')
-        when :chunk_length_kb then value.to_i
-        when :crc_check_chance then value.to_f
+        when :chunk_length_in_kb then Kernel.Integer(value)
+        when :crc_check_chance then Kernel.Float(value)
         else value.to_s
         end
       end

--- a/lib/cequel/schema/table_reader.rb
+++ b/lib/cequel/schema/table_reader.rb
@@ -160,20 +160,14 @@ module Cequel
 
       def table_data
         return @table_data if defined? @table_data
-        table_query = keyspace.execute(<<-CQL, keyspace.name, table_name)
-              SELECT * FROM system.schema_columnfamilies
-              WHERE keyspace_name = ? AND columnfamily_name = ?
-        CQL
+        table_query = keyspace.execute(Cassandra::Cluster::Schema::Fetchers::V3_0_x::SELECT_TABLE, keyspace.name, table_name)
         @table_data = table_query.first.try(:to_hash)
       end
 
       def all_columns
         @all_columns ||=
           if table_data
-            column_query = keyspace.execute(<<-CQL, keyspace.name, table_name)
-              SELECT * FROM system.schema_columns
-              WHERE keyspace_name = ? AND columnfamily_name = ?
-            CQL
+            column_query = keyspace.execute(Cassandra::Cluster::Schema::Fetchers::V3_0_x::SELECT_TABLE, keyspace.name, table_name)
             column_query.map(&:to_hash)
           end
       end

--- a/lib/cequel/schema/table_reader.rb
+++ b/lib/cequel/schema/table_reader.rb
@@ -7,13 +7,6 @@ module Cequel
     # that schema
     #
     class TableReader
-      COMPOSITE_TYPE_PATTERN =
-        /^org\.apache\.cassandra\.db\.marshal\.CompositeType\((.+)\)$/
-      REVERSED_TYPE_PATTERN =
-        /^org\.apache\.cassandra\.db\.marshal\.ReversedType\((.+)\)$/
-#      COLLECTION_TYPE_PATTERN =
-#        /^org\.apache\.cassandra\.db\.marshal\.(List|Set|Map)Type\((.+)\)$/
-
       # @return [Table] object representation of the table defined in the
       #   database
       attr_reader :table
@@ -121,18 +114,10 @@ module Cequel
         end
       end
 
-    
-
       def read_properties
         table_data.slice(*Table::STORAGE_PROPERTIES).each do |name, value|
           table.add_property(name, value)
         end        
-      end
-
-      def parse_composite_types(type_string)
-        if COMPOSITE_TYPE_PATTERN =~ type_string
-          $1.split(',')
-        end
       end
 
       def table_data
@@ -150,6 +135,7 @@ module Cequel
       end
 
       def compact_value
+        #TODO determine if this has test coverage and if it works or not in Cassandra 3
         @compact_value ||= all_columns.find do |column|
           column['type'] == 'compact_value'
         end || {}

--- a/lib/cequel/schema/table_reader.rb
+++ b/lib/cequel/schema/table_reader.rb
@@ -164,13 +164,6 @@ module Cequel
             index_query.map(&:to_hash)
           end
       end
-
-      def compact_value
-        #TODO determine if this has test coverage and if it works or not in Cassandra 3
-        @compact_value ||= all_columns.find do |column|
-          column['type'] == 'compact_value'
-        end || {}
-      end
       
       def compact_columns 
         @compact_columns ||= all_columns.select do |column|

--- a/lib/cequel/schema/table_reader.rb
+++ b/lib/cequel/schema/table_reader.rb
@@ -11,8 +11,8 @@ module Cequel
         /^org\.apache\.cassandra\.db\.marshal\.CompositeType\((.+)\)$/
       REVERSED_TYPE_PATTERN =
         /^org\.apache\.cassandra\.db\.marshal\.ReversedType\((.+)\)$/
-      COLLECTION_TYPE_PATTERN =
-        /^org\.apache\.cassandra\.db\.marshal\.(List|Set|Map)Type\((.+)\)$/
+#      COLLECTION_TYPE_PATTERN =
+#        /^org\.apache\.cassandra\.db\.marshal\.(List|Set|Map)Type\((.+)\)$/
 
       # @return [Table] object representation of the table defined in the
       #   database
@@ -64,29 +64,30 @@ module Cequel
 
       private
 
-      # XXX This gets a lot easier in Cassandra 2.0: all logical columns
-      # (including keys) are returned from the `schema_columns` query, so
-      # there's no need to jump through all these hoops to figure out what the
-      # key columns look like.
-      #
-      # However, this approach works for both 1.2 and 2.0, so better to keep it
-      # for now. It will be worth refactoring this code to take advantage of
-      # 2.0's better interface in a future version of Cequel that targets 2.0+.
       def read_partition_keys
-        validators = table_data['key_validator']
-        types = parse_composite_types(validators) || [validators]
-        columns = partition_columns.sort_by { |c| c['component_index'] }
-          .map { |c| c['column_name'] }
-
-        columns.zip(types) do |name, type|
-          table.add_partition_key(name.to_sym, Type.lookup_internal(type))
-        end
+        partition_columns.sort_by { |c| c.fetch('position') }
+          .each do |c|
+            name = c.fetch('column_name').to_sym
+            cql_type = Type.lookup_cql(c.fetch('type'))
+            table.add_partition_key(name, cql_type)
+          end
       end
 
-      # XXX See comment on {read_partition_keys}
       def read_clustering_columns
-        columns = cluster_columns.sort { |l, r| l['component_index'] <=> r['component_index'] }
-          .map { |c| c['column_name'] }
+        #TODO deal w/ compact storage? Does this class even care anymore ?
+        
+        cluster_columns.sort_by { |c| c.fetch('position') }
+          .each do |c| 
+            name = c.fetch('column_name').to_sym 
+            cql_type = Type.lookup_cql(c.fetch('type'))
+            clustering_order = c.fetch('clustering_order').to_sym
+            table.add_clustering_column(name, cql_type, clustering_order)
+          end
+        return 
+        
+        columns = cluster_columns.sort { |l, r| l.fetch('component_index') <=> r.fetch('component_index') }
+          .map { |c| c.fetch('column_name') }
+          
         comparators = parse_composite_types(table_data['comparator'])
         unless comparators
           table.compact_storage = true
@@ -108,6 +109,35 @@ module Cequel
         end
       end
 
+      COLLECTION_TYPE_PATTERN = /^(.+)<(.+)>/
+
+      def read_data_columns 
+        column_data.each do |result|
+          name = result.fetch('column_name').to_sym
+          
+          column_type = result.fetch('type')
+          m = COLLECTION_TYPE_PATTERN.match(column_type)
+          
+          if m.present? 
+            composition_type = m[1]
+            if composition_type != 'map' 
+              cql_type = Type.lookup_cql(m[2])
+              table.send("add_#{composition_type}", name, cql_type)
+            else 
+              composition_types = m[2].split(',').map(&:strip)
+              key_type = composition_types.fetch(0)
+              value_type = composition_types.fetch(1)
+              table.send("add_#{composition_type}", name, key_type, value_type)
+            end
+          else 
+            cql_type = Type.lookup_cql(column_type)
+            
+            table.add_data_column(name, cql_type)
+          end
+        end
+      end
+
+=begin
       def read_data_columns
         if column_data.empty?
           table.add_data_column(
@@ -119,13 +149,13 @@ module Cequel
           column_data.each do |result|
             if COLLECTION_TYPE_PATTERN =~ result['validator']
               read_collection_column(
-                result['column_name'],
+                result.fetch('column_name'),
                 $1.underscore,
                 *$2.split(',')
               )
             else
               table.add_data_column(
-                result['column_name'].to_sym,
+                result.fetch('column_name').to_sym,
                 Type.lookup_internal(result['validator']),
                 result['index_name'].try(:to_sym)
               )
@@ -139,17 +169,12 @@ module Cequel
           .map { |internal| Type.lookup_internal(internal) }
         table.__send__("add_#{collection_type}", name.to_sym, *types)
       end
+=end      
 
       def read_properties
         table_data.slice(*Table::STORAGE_PROPERTIES).each do |name, value|
           table.add_property(name, value)
-        end
-        compaction = JSON.parse(table_data['compaction_strategy_options'])
-          .symbolize_keys
-        compaction[:class] = table_data['compaction_strategy_class']
-        table.add_property(:compaction, compaction)
-        compression = JSON.parse(table_data['compression_parameters'])
-        table.add_property(:compression, compression)
+        end        
       end
 
       def parse_composite_types(type_string)
@@ -167,7 +192,7 @@ module Cequel
       def all_columns
         @all_columns ||=
           if table_data
-            column_query = keyspace.execute(Cassandra::Cluster::Schema::Fetchers::V3_0_x::SELECT_TABLE, keyspace.name, table_name)
+            column_query = keyspace.execute(Cassandra::Cluster::Schema::Fetchers::V3_0_x::SELECT_TABLE_COLUMNS, keyspace.name, table_name)
             column_query.map(&:to_hash)
           end
       end
@@ -180,19 +205,19 @@ module Cequel
 
       def column_data
         @column_data ||= all_columns.select do |column|
-          !column.key?('type') || column['type'] == 'regular'
+          !column.key?('kind') || column.fetch('kind') == 'regular'
         end
       end
 
       def partition_columns
         @partition_columns ||= all_columns.select do |column|
-          column['type'] == 'partition_key'
+          column.fetch('kind') == 'partition_key'
         end
       end
 
       def cluster_columns
         @cluster_columns ||= all_columns.select do |column|
-          column['type'] == 'clustering_key'
+          column.fetch('kind') == 'clustering'
         end
       end
     end

--- a/lib/cequel/version.rb
+++ b/lib/cequel/version.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
 module Cequel
   # The current version of the library
-  VERSION = '2.s0.0'
+  VERSION = '2.0.0'
 end

--- a/lib/cequel/version.rb
+++ b/lib/cequel/version.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
 module Cequel
   # The current version of the library
-  VERSION = '1.10.0'
+  VERSION = '2.s0.0'
 end

--- a/spec/examples/metal/data_set_spec.rb
+++ b/spec/examples/metal/data_set_spec.rb
@@ -738,7 +738,10 @@ describe Cequel::Metal::DataSet do
     end
 
     it 'should use limit if specified' do
-      expect(cequel[:posts].limit(2).count).to eq(2)
+      # In Cassandra 2.x, it is valid to specify limit with a 
+      # count query, but there is no meaninful effect on the result 
+      expect(cequel[:posts].limit(2).count_cql.first.downcase).to match("limit")
+      expect(cequel[:posts].limit(1).count).to eq(4) # Total number of rows in the table
     end
   end
 

--- a/spec/examples/metal/data_set_spec.rb
+++ b/spec/examples/metal/data_set_spec.rb
@@ -197,7 +197,7 @@ describe Cequel::Metal::DataSet do
       cequel[:posts].where(row_keys).
         list_prepend(:categories, ['Scalability', 'Partition Tolerance'])
       expect(cequel[:posts].where(row_keys).first[:categories]).to eq(
-        ['Partition Tolerance', 'Scalability', 'Big Data', 'Cassandra']
+        ['Scalability', 'Partition Tolerance', 'Big Data', 'Cassandra']
       )
     end
   end

--- a/spec/examples/record/persistence_spec.rb
+++ b/spec/examples/record/persistence_spec.rb
@@ -147,14 +147,25 @@ describe Cequel::Record::Persistence do
         end
 
         it 'should not mark itself as clean if save failed at Cassandra level' do
-          blog.name = 'Pizza'
-          with_client_error(Cassandra::Errors::InvalidError.new(1, 'error')) do
+          blog.name = 'Pizza'          
+          simulated_error = Cassandra::Errors::InvalidError.new('simulated error', 
+            {},
+            [],
+            'cequel_test',
+            'simulated statement;',
+            {},
+            ['host-a','host-b'],
+            :one,
+            1)
+                        
+            
+          with_client_error(simulated_error) do
             begin
               blog.save
             rescue Cassandra::Errors::InvalidError
             end
           end
-          blog.save
+          blog.save          
           expect(subject[:name]).to eq('Pizza')
         end
       end

--- a/spec/examples/record/record_set_spec.rb
+++ b/spec/examples/record/record_set_spec.rb
@@ -674,7 +674,9 @@ describe Cequel::Record::RecordSet do
     let(:records) { blogs }
 
     it 'should return the number of records requested' do
-      expect(Blog.limit(2).length).to eq(2)
+      # The method length is aliased to count, which does not work as expected 
+      # in Cassandra 2.x
+      expect(Blog.limit(2).find_each.to_a.length).to eq(2)
     end
   end
 

--- a/spec/examples/record/record_set_spec.rb
+++ b/spec/examples/record/record_set_spec.rb
@@ -674,7 +674,7 @@ describe Cequel::Record::RecordSet do
     let(:records) { blogs }
 
     it 'should return the number of records requested' do
-      expect(Blog.limit(2).length).to be(2)
+      expect(Blog.limit(2).length).to eq(2)
     end
   end
 

--- a/spec/examples/schema/keyspace_spec.rb
+++ b/spec/examples/schema/keyspace_spec.rb
@@ -29,7 +29,11 @@ describe Cequel::Schema::Keyspace do
     end
 
     let(:schema_config) do
-      connection.client.execute("SELECT * FROM system.schema_keyspaces WHERE keyspace_name = '#{keyspace_name}'").first
+      connection.client.execute("SELECT * FROM system_schema.keyspaces WHERE keyspace_name = '#{keyspace_name}'").first
+    end
+    
+    let!(:simple_strategy) do 
+      "org.apache.cassandra.locator.SimpleStrategy"
     end
 
     context 'with default options' do
@@ -38,10 +42,12 @@ describe Cequel::Schema::Keyspace do
       it 'uses default keyspace configuration' do
         keyspace.create!
         expect(schema_config).to eq({
-          "keyspace_name"=>keyspace_name,
-          "durable_writes"=>true,
-          "strategy_class"=>"org.apache.cassandra.locator.SimpleStrategy",
-          "strategy_options"=>"{\"replication_factor\":\"1\"}"
+          "keyspace_name" => keyspace_name,
+          "durable_writes" => true,
+          "replication" => {
+            "class" => simple_strategy,
+            "replication_factor" => "1"
+          }
         })
       end
     end
@@ -54,8 +60,10 @@ describe Cequel::Schema::Keyspace do
         expect(schema_config).to eq({
           "keyspace_name"=>keyspace_name,
           "durable_writes"=>true,
-          "strategy_class"=>"org.apache.cassandra.locator.SimpleStrategy",
-          "strategy_options"=>"{\"replication_factor\":\"2\"}"
+          "replication" => {
+            "class" => simple_strategy,
+            "replication_factor" => "2"
+          }
         })
       end
     end
@@ -68,8 +76,10 @@ describe Cequel::Schema::Keyspace do
         expect(schema_config).to eq({
           "keyspace_name"=>keyspace_name,
           "durable_writes"=>true,
-          "strategy_class"=>"org.apache.cassandra.locator.SimpleStrategy",
-          "strategy_options"=>"{\"replication_factor\":\"2\"}"
+          "replication" => {
+            "class" => simple_strategy,
+            "replication_factor" => "2"
+          }
         })
       end
 
@@ -90,10 +100,16 @@ describe Cequel::Schema::Keyspace do
         expect(schema_config).to eq({
           "keyspace_name"=>keyspace_name,
           "durable_writes"=>true,
-          "strategy_class"=>"org.apache.cassandra.locator.SimpleStrategy",
-          "strategy_options"=>"{\"replication_factor\":\"3\"}"
+          "replication" => {
+            "class" => simple_strategy,
+            "replication_factor" => "3"
+          }
         })
       end
+    end
+    
+    let!(:network_topology_strategy) do
+      "org.apache.cassandra.locator.NetworkTopologyStrategy"
     end
 
     context 'with another custom replication options' do
@@ -106,8 +122,11 @@ describe Cequel::Schema::Keyspace do
         expect(schema_config).to eq({
           "keyspace_name"=>keyspace_name,
           "durable_writes"=>true,
-          "strategy_class"=>"org.apache.cassandra.locator.NetworkTopologyStrategy",
-          "strategy_options"=>"{\"datacenter1\":\"3\",\"datacenter2\":\"2\"}"
+          "replication" => {
+            "class" => network_topology_strategy,
+            "datacenter1" => "3",
+            "datacenter2" => "2"  
+          }
         })
       end
     end
@@ -122,8 +141,10 @@ describe Cequel::Schema::Keyspace do
         expect(schema_config).to eq({
           "keyspace_name"=>keyspace_name,
           "durable_writes"=>false,
-          "strategy_class"=>"org.apache.cassandra.locator.SimpleStrategy",
-          "strategy_options"=>"{\"replication_factor\":\"1\"}"
+          "replication" => {
+            "class" => simple_strategy,
+            "replication_factor" => "1"
+          }
         })
       end
     end

--- a/spec/examples/schema/table_reader_spec.rb
+++ b/spec/examples/schema/table_reader_spec.rb
@@ -282,29 +282,29 @@ describe Cequel::Schema::TableReader do
     end
 
     it 'should read and simplify compaction class' do
-      expect(table.property(:compaction)[:class]).
+      expect(table.property(:compaction).fetch(:class)).
         to eq('SizeTieredCompactionStrategy')
     end
 
     it 'should read float properties from compaction hash' do
-      expect(table.property(:compaction)[:bucket_high]).to eq(1.8)
+      expect(table.property(:compaction).fetch(:bucket_high)).to eq(1.8)
     end
 
     it 'should read integer properties from compaction hash' do
-      expect(table.property(:compaction)[:max_threshold]).to eq(64)
+      expect(table.property(:compaction).fetch(:max_threshold)).to eq(64)
     end
-
+    
     it 'should read and simplify compression class' do
-      expect(table.property(:compression)[:sstable_compression]).
+      expect(table.property(:compression).fetch(:class)).
         to eq('DeflateCompressor')
     end
 
     it 'should read integer properties from compression class' do
-      expect(table.property(:compression)[:chunk_length_kb]).to eq(128)
+      expect(table.property(:compression).fetch(:chunk_length_in_kb)).to eq(128)
     end
 
     it 'should read float properties from compression class' do
-      expect(table.property(:compression)[:crc_check_chance]).to eq(0.5)
+      expect(table.property(:crc_check_chance)).to eq(0.5)
     end
 
     it 'should recognize no compact storage' do

--- a/spec/examples/schema/table_reader_spec.rb
+++ b/spec/examples/schema/table_reader_spec.rb
@@ -326,7 +326,8 @@ describe Cequel::Schema::TableReader do
     its(:partition_key_columns) { should ==
       [Cequel::Schema::PartitionKey.new(:permalink, :text)] }
     its(:clustering_columns) { should be_empty }
-    specify { expect(table.data_columns).to contain_exactly(
+    specify { 
+      expect(table.data_columns).to contain_exactly(
       Cequel::Schema::DataColumn.new(:title, :text),
       Cequel::Schema::DataColumn.new(:body, :text)) }
   end

--- a/spec/examples/schema/table_writer_spec.rb
+++ b/spec/examples/schema/table_writer_spec.rb
@@ -168,8 +168,8 @@ describe Cequel::Schema::TableWriter do
 
       it 'should set map collection properties' do
         expect(table.property(:compression)).to eq({
-          :sstable_compression => 'DeflateCompressor',
-          :chunk_length_kb => 64
+          :class => 'DeflateCompressor',
+          :chunk_length_in_kb => 64
         })
       end
     end

--- a/spec/examples/spec_support/preparation_spec.rb
+++ b/spec/examples/spec_support/preparation_spec.rb
@@ -84,12 +84,7 @@ describe Cequel::SpecSupport::Preparation do
 
   matcher :contain_table do |table_name|
     match do |keyspace|
-      keyspace.execute(<<-CQL).any?
-        SELECT columnfamily_name
-        FROM System.schema_columnfamilies
-        WHERE keyspace_name='#{keyspace.name}'
-          AND columnfamily_name='#{table_name}'
-      CQL
+      keyspace.execute(Cassandra::Cluster::Schema::Fetchers::V3_0_x::SELECT_TABLE, keyspace.name, table_name).any?
     end
   end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -55,7 +55,8 @@ module Cequel
         @cequel ||= Cequel.connect(
           host: host,
           port: port,
-          keyspace: keyspace_name
+          keyspace: keyspace_name,
+          cluster_options: {timeout: Integer(ENV.fetch('SPEC_TIMEOUT','60'))}
         ).tap do |cequel|
           if ENV['CEQUEL_LOG_QUERIES']
             cequel.logger = Logger.new(STDOUT)


### PR DESCRIPTION
I upgraded this gem to use Cassandra 3. It is not reverse compatible with prior versions of Cassandra, so I raised the gem major version.

The tests passed for me against 3.7.

This code is rather interested in the the metadata around table schemas. That was changed substantially between 2 & 3. I reverse engineering the python & ruby drivers for Cassandra3 as needed to figure out how to query all of that stuff. I tried to use the constants defined by the ruby driver gem where appropriate. Compact tables are really annoying, and apparently have no use in Cassandra3 according to this:

http://www.datastax.com/2015/12/storage-engine-30

It might be worthwhile to just drop compact storage support in the future.

I also added an option to allow the passing of arbitrary options to the underlying Cassandra gem. I need to be able to reconfigure the node selection strategy as well as other parameters. I don't think this hurts anything as users clearly are on their own if they start reconfiguring the underlying client.

Let me know if you need anything else to accept this MR.