### PR TITLE
drop index if it exists

### DIFF
--- a/lib/cequel/schema/table_updater.rb
+++ b/lib/cequel/schema/table_updater.rb
@@ -149,7 +149,7 @@ module Cequel
       # @return [void]
       #
       def drop_index(index_name)
-        statements << "DROP INDEX #{index_name}"
+        statements << "DROP INDEX IF EXISTS #{index_name}"
       end
 
       # @!visibility protected

--- a/spec/examples/schema/table_updater_spec.rb
+++ b/spec/examples/schema/table_updater_spec.rb
@@ -121,16 +121,31 @@ describe Cequel::Schema::TableUpdater do
   end
 
   describe '#drop_index' do
-    before do
-      tab_name = table_name
-      cequel.schema.alter_table(table_name) do
-        create_index :title
-        drop_index :"#{tab_name}_title_idx"
+    context 'index exists' do
+      before do
+        tab_name = table_name
+        cequel.schema.alter_table(table_name) do
+          create_index :title
+          drop_index :"#{tab_name}_title_idx"
+        end
+      end
+
+      it 'should drop the index' do
+        expect(table.data_column(:title)).not_to be_indexed
       end
     end
 
-    it 'should drop the index' do
-      expect(table.data_column(:title)).not_to be_indexed
+    context 'index does not exist' do
+      before do
+        tab_name = table_name
+        cequel.schema.alter_table(table_name) do
+          drop_index :"#{tab_name}_title_idx"
+        end
+      end
+
+      it 'should nop on non existent index' do
+        expect(table.data_column(:title)).not_to be_indexed
+      end
     end
   end
 


### PR DESCRIPTION
Cequel gets confused of the schema state when an index is dropped outside of a cequel migration. We should only drop the index when it exists.