### PR TITLE
Bump cassandra driver version

### DIFF
--- a/cequel.gemspec
+++ b/cequel.gemspec
@@ -28,7 +28,7 @@ DESC
   s.extra_rdoc_files = 'README.md'
   s.required_ruby_version = '>= 2.0'
   s.add_runtime_dependency 'activemodel', '~> 4.0'
-  s.add_runtime_dependency 'cassandra-driver', '~> 2.0'
+  s.add_runtime_dependency 'cassandra-driver', '~> 3.0'
   s.add_development_dependency 'appraisal', '~> 1.0'
   s.add_development_dependency 'wwtd', '~> 0.5'
   s.add_development_dependency 'rake', '~> 10.1'

--- a/lib/cequel/metal/keyspace.rb
+++ b/lib/cequel/metal/keyspace.rb
@@ -327,7 +327,7 @@ module Cequel
 
       def extract_hosts_and_port(configuration)
         hosts, ports = [], Set[]
-        ports << configuration[:port] if configuration.key?(:port)
+        ports << Integer(configuration[:port]) if configuration.key?(:port)
         host_or_hosts =
           configuration.fetch(:host, configuration.fetch(:hosts, '127.0.0.1'))
         Array.wrap(host_or_hosts).each do |host_port|
@@ -337,7 +337,7 @@ module Cequel
             warn "Specifying a hostname as host:port is deprecated. Specify " \
                  "only the host IP or hostname in :hosts, and specify a " \
                  "port for all nodes using the :port option."
-            ports << port.to_i
+            ports << Integer(port)
           end
         end
 

--- a/lib/cequel/version.rb
+++ b/lib/cequel/version.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
 module Cequel
   # The current version of the library
-  VERSION = '1.10.0'
+  VERSION = '1.11.0'
 end

--- a/spec/examples/record/persistence_spec.rb
+++ b/spec/examples/record/persistence_spec.rb
@@ -148,7 +148,7 @@ describe Cequel::Record::Persistence do
 
         it 'should not mark itself as clean if save failed at Cassandra level' do
           blog.name = 'Pizza'
-          with_client_error(Cassandra::Errors::InvalidError.new(1, 'error')) do
+          with_client_error(Cassandra::Errors::InvalidError.new(nil, nil, nil, nil, nil, nil, nil, nil, nil)) do
             begin
               blog.save
             rescue Cassandra::Errors::InvalidError


### PR DESCRIPTION
Upgrade cassandra driver version to 3.x. This does not change the versions of cassandra supported by Cequel.