### PR TITLE
Fix new relic instrumentation

### DIFF
--- a/lib/cequel/version.rb
+++ b/lib/cequel/version.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
 module Cequel
   # The current version of the library
-  VERSION = '2.0.1'
+  VERSION = '2.0.2'
 end


### PR DESCRIPTION
It looks like no one gave the new relic instrumentation any love in the 2.0.0 upgrade.

It fails for me in production, because the actual parameters are different in 2.0.0.

This fixes it for me.