### PR TITLE
Add synchronization around use of @cluster and other variables Fix #332

### DIFF
--- a/lib/cequel/metal/keyspace.rb
+++ b/lib/cequel/metal/keyspace.rb
@@ -94,8 +94,8 @@ module Cequel
       # @see Cequel.connect
       #
       def initialize(configuration={})
-        configure(configuration)
         @lock = Monitor.new
+        configure(configuration)
       end
 
       #
@@ -241,15 +241,17 @@ module Cequel
       # @return [void]
       #
       def clear_active_connections!
-        if defined? @client
-          remove_instance_variable(:@client)
-        end
-        if defined? @client_without_keyspace
-          remove_instance_variable(:@client_without_keyspace)
-        end
-        if defined? @cluster
-          @cluster.close
-          remove_instance_variable(:@cluster)
+        synchronize do
+          if defined? @client
+            remove_instance_variable(:@client)
+          end
+          if defined? @client_without_keyspace
+            remove_instance_variable(:@client_without_keyspace)
+          end
+          if defined? @cluster
+            @cluster.close
+            remove_instance_variable(:@cluster)
+          end
         end
       end
 


### PR DESCRIPTION
This class has the correct primitives to be thread safe, but it was missing a `synchronize` block.
Fix #332