### PR TITLE
expose if the dataset is on the last page

### DIFF
--- a/lib/cequel/metal/data_set.rb
+++ b/lib/cequel/metal/data_set.rb
@@ -579,8 +579,24 @@ module Cequel
         end
       end
 
+      #
+      # Exposes current paging state for stateless pagination
+      #
+      # @return [String] or nil
+      #
+      # @see http://docs.datastax.com/en/developer/ruby-driver/3.0/api/cassandra/result/#paging_state-instance_method
+      #
       def next_paging_state
         results.paging_state
+      end
+
+      #
+      # @return [Boolean] Returns whether no more pages are available
+      #
+      # @see http://docs.datastax.com/en/developer/ruby-driver/3.0/api/cassandra/result/#last_page?-instance_method
+      #
+      def last_page?
+        results.last_page?
       end
 
       # rubocop:enable LineLength

--- a/lib/cequel/record/record_set.rb
+++ b/lib/cequel/record/record_set.rb
@@ -488,6 +488,10 @@ module Cequel
         data_set.next_paging_state
       end
 
+      def last_page?
+        data_set.last_page?
+      end
+
       #
       # @overload first
       #   @return [Record] the first record in this record set


### PR DESCRIPTION
When working with paging you need to be able to determine if you are on the last page. If you are manually looping over a collection instead of using `.each` the `last_page?` comes in handy because `nil` is a valid paging state, it just means start at the beginning.

By exposing the paging state we are now able to write code like this:
```ruby
paging_state = nil
loop do
  posts = blog.posts.page_size(100).paging_state(paging_state)
  paging_state = posts.next_paging_state
  posts.approve!
  break if posts.last_page?
end
```