### PR TITLE
Delegate error handling to a policy object, allow for arbitrary options to be passed to cassandra driver gem

### DIFF
--- a/lib/cequel.rb
+++ b/lib/cequel.rb
@@ -8,6 +8,7 @@ require 'cassandra'
 
 require 'cequel/errors'
 require 'cequel/util'
+require 'cequel/metal/policy/cassandra_error'
 require 'cequel/metal'
 require 'cequel/schema'
 require 'cequel/type'

--- a/lib/cequel/metal/keyspace.rb
+++ b/lib/cequel/metal/keyspace.rb
@@ -413,10 +413,10 @@ module Cequel
         value = configuration.fetch(:cassandra_error_policy, ::Cequel::Metal::Policy::CassandraError::ClearAndRetryPolicy)
         # Accept a class name as a string, create an instance of it 
         if value.is_a?(String)
-          value.constantize.new
+          value.constantize.new(configuration)
         # Accept a class, instantiate it
         elsif value.is_a?(Class)
-          value.new 
+          value.new(configuration)
         # Accept a value, assume it is a ready to use policy object
         else 
           value

--- a/lib/cequel/metal/keyspace.rb
+++ b/lib/cequel/metal/keyspace.rb
@@ -126,6 +126,10 @@ module Cequel
       #   key
       # @option configuration [String] :passphrase the passphrase for client
       #   private key
+      # @option configuration [String] :cassandra_error_policy A mixin for 
+      #   handling errors from Cassandra
+      # @option configuration [Hash] :cassandra_options A hash of arbitrary
+      #   options to pass to Cassandra
       # @return [void]
       #
       def configure(configuration = {})

--- a/lib/cequel/metal/keyspace.rb
+++ b/lib/cequel/metal/keyspace.rb
@@ -56,7 +56,7 @@ module Cequel
       #   consistency. Will be included the current batch operation if one is
       #   present.
       #
-      #   @param (see #execute_with_consistency)
+      #   @param (see #execute_with_options)
       #   @return [void]
       #
       def_delegator :write_target, :execute_with_options,
@@ -194,7 +194,7 @@ module Cequel
       # @param bind_vars [Object] values for bind variables
       # @return [Enumerable] the results of the query
       #
-      # @see #execute_with_consistency
+      # @see #execute_with_options
       #
       def execute(statement, *bind_vars)
         execute_with_options(Statement.new(statement, bind_vars), { consistency: default_consistency })

--- a/lib/cequel/metal/policy/cassandra_error.rb
+++ b/lib/cequel/metal/policy/cassandra_error.rb
@@ -3,6 +3,18 @@ module Cequel
   module Metal
     module Policy
       module CassandraError
+        # This mixin is used by the Keyspace object to dictate 
+        # how a failure from Cassandra is handled.
+        # The only method defined is 
+        #   handle_error(error, retries_remaining)
+        # The first argument is the error from the Cassandra gem.
+        # The second argument is the number of remaining retries.
+        # This function must raise the error to abort the operation,
+        # if this function returns it indicates the operation should be 
+        # retried.
+        # 
+        # The specific mixin is chosen by passing configuration options
+        # See Keyspace#configure 
         module ClearAndRetry
           def handle_error(error, retries_remaining)
             clear_active_connections!

--- a/lib/cequel/metal/policy/cassandra_error.rb
+++ b/lib/cequel/metal/policy/cassandra_error.rb
@@ -7,13 +7,9 @@ module Cequel
           # This class is used by the Keyspace object to dictate 
           # how a failure from Cassandra is handled.
           # The only method defined is 
-          #   handle_error(keyspace, error, retries_remaining)
+          #   execute_stmt(keyspace)
           # The first argument is an instance of the Keyspace class
-          # The second argument is the error from the Cassandra gem.
-          # The thid argument is the number of remaining retries.
-          # This function must raise the error to abort the operation,
-          # if this function returns it indicates the operation should be 
-          # retried.
+          # This method may raise an error to abort the operation,
           # 
           # The specific instance is chosen by passing configuration options
           # See Keyspace#configure
@@ -23,8 +19,8 @@ module Cequel
           def initialize(options = {})
           end
                     
-          def handle_error(error, retries_remaining)
-            raise RuntimeError, 'This is an abstract base class, never call this'
+          def execute_stmt(keyspace)
+            raise NotImplementedError, "#execute_stmt must be implemented in #{self.class.name}"
           end
         end
          

--- a/lib/cequel/metal/policy/cassandra_error.rb
+++ b/lib/cequel/metal/policy/cassandra_error.rb
@@ -3,7 +3,7 @@ module Cequel
   module Metal
     module Policy
       module CassandraError
-        class ErrorPolicyBase        
+        class ErrorPolicyBase                  
           # This class is used by the Keyspace object to dictate 
           # how a failure from Cassandra is handled.
           # The only method defined is 
@@ -16,7 +16,13 @@ module Cequel
           # retried.
           # 
           # The specific instance is chosen by passing configuration options
-          # See Keyspace#configure          
+          # See Keyspace#configure
+          
+          # On instantiation, the configuraiton hash passed to Cequel is 
+          # available here
+          def initialize(options = {})
+          end
+                    
           def handle_error(error, retries_remaining)
             raise RuntimeError, 'This is an abstract base class, never call this'
           end

--- a/lib/cequel/metal/policy/cassandra_error.rb
+++ b/lib/cequel/metal/policy/cassandra_error.rb
@@ -3,35 +3,42 @@ module Cequel
   module Metal
     module Policy
       module CassandraError
-        # This mixin is used by the Keyspace object to dictate 
-        # how a failure from Cassandra is handled.
-        # The only method defined is 
-        #   handle_error(error, retries_remaining)
-        # The first argument is the error from the Cassandra gem.
-        # The second argument is the number of remaining retries.
-        # This function must raise the error to abort the operation,
-        # if this function returns it indicates the operation should be 
-        # retried.
-        # 
-        # The specific mixin is chosen by passing configuration options
-        # See Keyspace#configure 
-        module ClearAndRetry
+        class ErrorPolicyBase        
+          # This class is used by the Keyspace object to dictate 
+          # how a failure from Cassandra is handled.
+          # The only method defined is 
+          #   handle_error(keyspace, error, retries_remaining)
+          # The first argument is an instance of the Keyspace class
+          # The second argument is the error from the Cassandra gem.
+          # The thid argument is the number of remaining retries.
+          # This function must raise the error to abort the operation,
+          # if this function returns it indicates the operation should be 
+          # retried.
+          # 
+          # The specific instance is chosen by passing configuration options
+          # See Keyspace#configure          
           def handle_error(error, retries_remaining)
-            clear_active_connections!
+            raise RuntimeError, 'This is an abstract base class, never call this'
+          end
+        end
+         
+        class ClearAndRetryPolicy < ErrorPolicyBase 
+          def handle_error(keyspace, error, retries_remaining)
+            keyspace.clear_active_connections!
             raise error if retries_remaining == 0
-            sleep(retry_delay)          
+            sleep(keyspace.retry_delay)          
           end
         end
         
-        module Retry
-          def handle_error(error, retries_remaining)
+        class RetryPolicy < ErrorPolicyBase
+          def handle_error(keyspace, error, retries_remaining)
             raise error if retries_remaining == 0
-            sleep(retry_delay)          
+            sleep(keyspace.retry_delay)          
           end
         end
         
-        module Raise
-          def handle_error(error, retries_remaining)
+        class RaisePolicy < ErrorPolicyBase
+          def handle_error(keyspace, error, retries_remaining)
             raise error
           end
         end

--- a/lib/cequel/metal/policy/cassandra_error.rb
+++ b/lib/cequel/metal/policy/cassandra_error.rb
@@ -1,0 +1,28 @@
+module Cequel
+  module Metal
+    module Policy
+      module CassandraError
+        module ClearAndRetry
+          def handle_error(error, retries_remaining)
+            clear_active_connections!
+            raise error if retries_remaining == 0
+            sleep(retry_delay)          
+          end
+        end
+        
+        module Retry
+          def handle_error(error, retries_remaining)
+            raise error if retries_remaining == 0
+            sleep(retry_delay)          
+          end
+        end
+        
+        module Raise
+          def handle_error(error, retries_remaining)
+            raise error
+          end
+        end
+      end 
+    end
+  end 
+end

--- a/lib/cequel/metal/policy/cassandra_error.rb
+++ b/lib/cequel/metal/policy/cassandra_error.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module Cequel
   module Metal
     module Policy

--- a/lib/cequel/record/persistence.rb
+++ b/lib/cequel/record/persistence.rb
@@ -173,7 +173,7 @@ module Cequel
       # @param options [Options] options for save
       # @option options [Boolean] :validate (true) whether to run validations
       #   before saving
-      # @option options [Symbol] :consistency (:quorum) what consistency with
+      # @option options [Symbol] :consistency what consistency with
       #   which to persist the changes
       # @option options [Integer] :ttl time-to-live of the updated rows in
       #   seconds
@@ -211,7 +211,7 @@ module Cequel
       # Remove this record from the database
       #
       # @param options [Options] options for deletion
-      # @option options [Symbol] :consistency (:quorum) what consistency with
+      # @option options [Symbol] :consistency what consistency with
       #   which to persist the deletion
       # @option options [Time] :timestamp the writetime to use for the deletion
       #

--- a/lib/cequel/version.rb
+++ b/lib/cequel/version.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
 module Cequel
   # The current version of the library
-  VERSION = '2.0.2'
+  VERSION = '2.0.3'
 end

--- a/spec/examples/metal/keyspace_spec.rb
+++ b/spec/examples/metal/keyspace_spec.rb
@@ -141,6 +141,9 @@ describe Cequel::Metal::Keyspace do
     end 
     
     class SpecCassandraErrorHandler
+      def initialize(options = {})
+      end
+      
       def handle_error(keyspace, error, retries_remaining)
         raise error 
       end

--- a/spec/examples/metal/keyspace_spec.rb
+++ b/spec/examples/metal/keyspace_spec.rb
@@ -115,6 +115,42 @@ describe Cequel::Metal::Keyspace do
       expect(connect.client_compression).to eq client_compression
     end
   end
+  
+  describe '#cassandra_options' do 
+    let(:cassandra_options) { {foo: :bar} }
+    let(:connect) do
+      Cequel.connect host: Cequel::SpecSupport::Helpers.host,
+          port: Cequel::SpecSupport::Helpers.port,
+          cassandra_options: cassandra_options
+    end
+    it 'passes the cassandra options as part of the client options' do 
+      expect(connect.send(:client_options)).to have_key(:foo)
+    end
+  end
+  
+  describe 'cassandra error handling' do 
+    module SpecCassandraErrorHandler
+      def handle_error(error, retries_remaining)
+        raise error 
+      end
+    end
+    
+    it 'uses the error handler passed in as a string' do 
+      obj = Cequel.connect host: Cequel::SpecSupport::Helpers.host,
+          port: Cequel::SpecSupport::Helpers.port,
+          cassandra_error_policy: 'SpecCassandraErrorHandler'
+          
+      expect(obj.method(:handle_error).owner).to equal(SpecCassandraErrorHandler)
+    end 
+    
+    it 'uses the error handler passed in as a module' do 
+      obj = Cequel.connect host: Cequel::SpecSupport::Helpers.host,
+          port: Cequel::SpecSupport::Helpers.port,
+          cassandra_error_policy: 'SpecCassandraErrorHandler'
+          
+      expect(obj.method(:handle_error).owner).to equal(SpecCassandraErrorHandler)
+    end
+  end
 
   describe "#execute" do
     let(:statement) { "SELECT id FROM posts" }


### PR DESCRIPTION
After refactoring some of the keyspace object, I can't really figure out why you would want to call `clear_active_connections!` after each error. This may have worked around some shortcomings in the cassandra driver gem historically, but I don't think it is a very good idea. The cassandra driver gem supports an infinite amount of configuration in the form of policy objects, which can be used to implement whatever handling logic you would like. It also tracks what hosts are up and down, so there is little reason to clear the connections on an error. I also can't see why you would to do retries in this gem, given that the cassandra driver gem can do that for you.

What I've seen in production systems is that once our application encounters a single timeout, all application threads immediately start hammering all the nodes. I think this is because clearing the connections makes the driver gem "forget" which hosts are up and down. 

All that taken into consideration, I don't want to change the default behavior because that would make the version '3.0.0' basically. So instead I have added two options to the configuration hash passed to this gem

1. cassandra_error_policy
2. cassandra_options

Using these two options, you can disable the default behavior and pass whatever options you would like to the underlying driver gem. Specifically, specifying a behavior of `Cequel::Metal::Keyspace::Policy::CassandraError::Raise` results in errors from the cassandra driver gem simply propagating up the call stack.

Let me know if you need anything else to accept this merge.