### PR TITLE
skip synchronizing materialized view

### DIFF
--- a/lib/cequel/record/schema.rb
+++ b/lib/cequel/record/schema.rb
@@ -80,9 +80,21 @@ module Cequel
         # @return [void]
         #
         def synchronize_schema
-          return if connection.schema.materialized_view?(table_name)
+          reader = get_table_reader
+          return if reader.materialized_view?
           Cequel::Schema::TableSynchronizer
-            .apply(connection, read_schema, table_schema)
+            .apply(connection, reader.read, table_schema)
+        end
+
+        #
+        # Return a {TableReader} instance
+        #
+        # @return [Schema::TableReader] object
+        #
+        def get_table_reader
+          fail MissingTableNameError unless table_name
+
+          connection.schema.get_table_reader(table_name)
         end
 
         #
@@ -93,9 +105,7 @@ module Cequel
         #   table in the database
         #
         def read_schema
-          fail MissingTableNameError unless table_name
-
-          connection.schema.read_table(table_name)
+          table_reader.read
         end
 
         #

--- a/lib/cequel/record/schema.rb
+++ b/lib/cequel/record/schema.rb
@@ -80,10 +80,9 @@ module Cequel
         # @return [void]
         #
         def synchronize_schema
-          unless connection.schema.materialized_view?(table_name)
-            Cequel::Schema::TableSynchronizer
-              .apply(connection, read_schema, table_schema)
-          end
+          return if connection.schema.materialized_view?(table_name)
+          Cequel::Schema::TableSynchronizer
+            .apply(connection, read_schema, table_schema)
         end
 
         #

--- a/lib/cequel/record/schema.rb
+++ b/lib/cequel/record/schema.rb
@@ -80,8 +80,10 @@ module Cequel
         # @return [void]
         #
         def synchronize_schema
-          Cequel::Schema::TableSynchronizer
-            .apply(connection, read_schema, table_schema)
+          unless connection.schema.materialized_view?(table_name)
+            Cequel::Schema::TableSynchronizer
+              .apply(connection, read_schema, table_schema)
+          end
         end
 
         #

--- a/lib/cequel/schema/keyspace.rb
+++ b/lib/cequel/schema/keyspace.rb
@@ -119,11 +119,11 @@ module Cequel
       end
 
       #
-      # @param name [Symbol] name of the table to check
-      # @return [boolean] true if it is materialized view
+      # @param name [Symbol] name of the table to read
+      # @return [TableReader] object
       #
-      def materialized_view?(name)
-        TableReader.materialized_view?(keyspace, name)
+      def get_table_reader(name)
+        TableReader.get(keyspace, name)
       end
 
       #
@@ -196,6 +196,16 @@ module Cequel
       #
       def drop_table(name)
         keyspace.execute("DROP TABLE #{name}")
+      end
+
+      #
+      # Drop this materialized view from the keyspace
+      #
+      # @param name [Symbol] name of the materialized view to drop
+      # @return [void]
+      #
+      def drop_materialized_view(name)
+        keyspace.execute("DROP MATERIALIZED VIEW #{name}")
       end
 
       #

--- a/lib/cequel/schema/keyspace.rb
+++ b/lib/cequel/schema/keyspace.rb
@@ -119,6 +119,14 @@ module Cequel
       end
 
       #
+      # @param name [Symbol] name of the table to check
+      # @return [boolean] true if it is materialized view
+      #
+      def materialized_view?(name)
+        TableReader.materialized_view?(keyspace, name)
+      end
+
+      #
       # Create a table in the keyspace
       #
       # @param name [Symbol] name of the new table to create

--- a/lib/cequel/schema/table_reader.rb
+++ b/lib/cequel/schema/table_reader.rb
@@ -178,13 +178,13 @@ module Cequel
 
       def cluster
         @cluster ||= begin
-          cluster = keyspace.cluster
+          tmp_cluster = keyspace.cluster
           refresh(keyspace)
 
           fail(NoSuchKeyspaceError, "No such keyspace #{keyspace.name}") if
-            !cluster.has_keyspace?(keyspace.name)
+            !tmp_cluster.has_keyspace?(keyspace.name)
 
-          cluster
+          tmp_cluster
         end
       end
 

--- a/lib/cequel/schema/table_reader.rb
+++ b/lib/cequel/schema/table_reader.rb
@@ -30,13 +30,13 @@ module Cequel
       end
 
       #
-      # Check if it is materialized view
+      # Return a {TableReader} instance
       #
       # @param (see #initialize)
-      # @return (see #materialized_view?)
+      # @return [TableReader] object
       #
-      def self.materialized_view?(keyspace, table_name)
-        new(keyspace, table_name).materialized_view?
+      def self.get(keyspace, table_name)
+        new(keyspace, table_name)
       end
 
       #
@@ -178,21 +178,14 @@ module Cequel
 
       def cluster
         @cluster ||= begin
-          tmp_cluster = keyspace.cluster
-          refresh(keyspace)
+          cluster = keyspace.cluster
+          cluster.refresh_schema
 
           fail(NoSuchKeyspaceError, "No such keyspace #{keyspace.name}") if
-            !tmp_cluster.has_keyspace?(keyspace.name)
+            !cluster.has_keyspace?(keyspace.name)
 
-          tmp_cluster
+          cluster
         end
-      end
-
-      @@refreshed = {}
-      def refresh(keyspace)
-        return if @@refreshed[keyspace.name]
-        @@refreshed[keyspace.name] = true
-        keyspace.cluster.refresh_schema
       end
     end
   end


### PR DESCRIPTION
If I have a materialized view by creating manually and define the model, it will cause error when synchronizing. I want to skip it.
It's better to support define materialized view by cequel, but I think we can skip and prevent error for now.