### PR TITLE
test as default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,8 @@ require File.expand_path('../lib/cequel/version', __FILE__)
 
 RUBY_VERSIONS = YAML.load_file(File.expand_path('../.travis.yml', __FILE__))['rvm']
 
-task :default => :release
+task default: :test
+
 task :release => [
   :verify_changelog,
   :"test:all",


### PR DESCRIPTION
this is a small change that would make the repository follow the rule of least surprise for contributors (like myself).

when i'm forking a project and trying to provide a PR i usually run `bundle exec rake` as almost all libraries then run the test-suite as their default task.

thanks for the great library!