### PR TITLE
hack in allow_filtering

### DIFF
--- a/lib/cequel/metal/data_set.rb
+++ b/lib/cequel/metal/data_set.rb
@@ -50,6 +50,7 @@ module Cequel
       attr_reader :query_consistency
       attr_reader :query_page_size
       attr_reader :query_paging_state
+      attr_reader :allow_filtering
 
       def_delegator :keyspace, :write_with_options
 
@@ -573,6 +574,12 @@ module Cequel
         end
       end
 
+      def allow_filtering!
+        clone.tap do |data_set|
+          data_set.allow_filtering = true
+        end
+      end
+
       def paging_state(paging_state)
         clone.tap do |data_set|
           data_set.query_paging_state = paging_state
@@ -645,6 +652,7 @@ module Cequel
           .append(*row_specifications_cql)
           .append(sort_order_cql)
           .append(limit_cql)
+          .append(allow_filtering_cql)
       end
 
       #
@@ -675,9 +683,17 @@ module Cequel
         end
       end
 
+      # @private
+      def allow_filtering_cql
+        if allow_filtering
+          ' ALLOW FILTERING'
+        else ''
+        end
+      end
+
       protected
 
-      attr_writer :row_limit, :query_consistency, :query_page_size, :query_paging_state
+      attr_writer :row_limit, :query_consistency, :query_page_size, :query_paging_state, :allow_filtering
 
       private
 

--- a/lib/cequel/metal/data_set.rb
+++ b/lib/cequel/metal/data_set.rb
@@ -574,6 +574,9 @@ module Cequel
         end
       end
 
+      #
+      # @see RecordSet#allow_filtering!
+      #
       def allow_filtering!
         clone.tap do |data_set|
           data_set.allow_filtering = true

--- a/lib/cequel/record/data_set_builder.rb
+++ b/lib/cequel/record/data_set_builder.rb
@@ -40,6 +40,7 @@ module Cequel
         add_bounds
         add_order
         set_consistency
+        set_allow_filtering
         set_page_size
         set_paging_state
         data_set
@@ -53,7 +54,8 @@ module Cequel
                      :scoped_key_names, :scoped_key_values,
                      :scoped_indexed_column, :lower_bound,
                      :upper_bound, :reversed?, :order_by_column,
-                     :query_consistency, :query_page_size, :query_paging_state, :ascends_by?
+                     :query_consistency, :query_page_size, :query_paging_state,
+                     :ascends_by?, :allow_filtering
 
       private
 
@@ -96,6 +98,12 @@ module Cequel
       def set_consistency
         if query_consistency
           self.data_set = data_set.consistency(query_consistency)
+        end
+      end
+
+      def set_allow_filtering
+        if allow_filtering
+          self.data_set = data_set.allow_filtering!
         end
       end
 

--- a/lib/cequel/record/record_set.rb
+++ b/lib/cequel/record/record_set.rb
@@ -465,10 +465,16 @@ module Cequel
       end
 
       #
-      # Set the consistency at which to read records into the record set.
+      # Add `ALLOW FILTERING` to select-queries for filtering of none-indexed fields.
       #
-      # @param consistency [Symbol] consistency for reads
+      # `Post.allow_filtering!.where(title: 'Cequel 0')`
+      #
+      # Available as of Cassandra 3.6
+      #
       # @return [RecordSet] record set tuned to given consistency
+
+      # @see https://docs.datastax.com/en/cql/3.3/cql/cql_reference/cqlSelect.html#cqlSelect__filtering-on-clustering-column
+      # @note Filtering can incurr a significant performance overhead or even timeout on a large data-set.
       #
       def allow_filtering!
         scoped(allow_filtering: true)

--- a/lib/cequel/record/record_set.rb
+++ b/lib/cequel/record/record_set.rb
@@ -465,6 +465,16 @@ module Cequel
       end
 
       #
+      # Set the consistency at which to read records into the record set.
+      #
+      # @param consistency [Symbol] consistency for reads
+      # @return [RecordSet] record set tuned to given consistency
+      #
+      def allow_filtering!
+        scoped(allow_filtering: true)
+      end
+
+      #
       # Set the page_size at which to read records into the record set.
       #
       # @param page_size [Integer] page_size for reads
@@ -695,10 +705,11 @@ module Cequel
       hattr_reader :attributes, :select_columns, :scoped_key_values,
                    :row_limit, :lower_bound, :upper_bound,
                    :scoped_indexed_column, :query_consistency,
-                   :query_page_size, :query_paging_state
+                   :query_page_size, :query_paging_state,
+                   :allow_filtering
       protected :select_columns, :scoped_key_values, :row_limit, :lower_bound,
                 :upper_bound, :scoped_indexed_column, :query_consistency,
-                :query_page_size, :query_paging_state
+                :query_page_size, :query_paging_state, :allow_filtering
       hattr_inquirer :attributes, :reversed
       protected :reversed?
 
@@ -812,7 +823,7 @@ module Cequel
           fail IllegalQuery,
                "Can't scope by more than one indexed column in the same query"
         end
-        unless column.indexed?
+        unless column.indexed? || allow_filtering
           fail ArgumentError,
                "Can't scope by non-indexed column #{column_name}"
         end

--- a/spec/examples/record/record_set_spec.rb
+++ b/spec/examples/record/record_set_spec.rb
@@ -806,7 +806,7 @@ describe Cequel::Record::RecordSet do
       end
     end
 
-    context 'allow_filtering!' do
+    context 'allow_filtering!', cassandra: '~> 3.x' do
       it 'should allow filtering for none indexed columns' do
         expect(Post.allow_filtering!.where(title: 'Cequel 0').entries.length).to be(1)
       end

--- a/spec/examples/record/record_set_spec.rb
+++ b/spec/examples/record/record_set_spec.rb
@@ -805,6 +805,12 @@ describe Cequel::Record::RecordSet do
           to raise_error(ArgumentError)
       end
     end
+
+    context 'allow_filtering!' do
+      it 'should allow filtering for none indexed columns' do
+        expect(Post.allow_filtering!.where(title: 'Cequel 0').entries.length).to be(1)
+      end
+    end
   end
 
   describe '#consistency' do


### PR DESCRIPTION
for reference: https://github.com/cequel/cequel/issues/208#issuecomment-273941857

this is a working prototype for adding `ALLOW FILTERING` support. the way that i squeezed it into the existing codebase will make it work like `Post.allow_filtering!.where(title: 'Cequel 0')`. 

`allow_filtering!` will have to be called (like ie `consitency(:all)`) before calling `where`. this is mainly due to the `ArgumentError` that will otherwise be thrown in `filter_secondary_index`.

that does not feel very sexy to me though...

i'd like to get some early feedback before proceeding.