### PR TITLE
fix documentation to have 2 args

### DIFF
--- a/lib/cequel/instrumentation.rb
+++ b/lib/cequel/instrumentation.rb
@@ -14,7 +14,7 @@ module Cequel
       # Example:
       #
       #    extend Instrumentation
-      #    instrument :create, "create.cequel", data: {table_name: table_name}
+      #    instrument :create, data: {topic: "create.cequel", table_name: table_name}
       #
       # @param method_name [Symbol,String] The method to instrument
       #


### PR DESCRIPTION
was copying the method signature from the docs, but it does only take 2 args now.

i'm unsure about updating the rest of the docs, looks like quite a lot has changed there...