### PR TITLE
Fix parsing of uuids from strings

### DIFF
--- a/lib/cequel/uuids.rb
+++ b/lib/cequel/uuids.rb
@@ -34,10 +34,18 @@ module Cequel
     # @return [Boolean] true if the object is recognized by Cequel as a UUID
     #
     def uuid?(object)
+      return true if uuid_in_string?(object)
+
       object.is_a?(Cassandra::Uuid)
     end
 
     private
+
+    def uuid_in_string?(object)
+      object.is_a?(String) && Cassandra::Uuid.new(object)
+    rescue ArgumentError
+      false
+    end
 
     def timeuuid_generator
       @timeuuid_generator ||= Cassandra::TimeUuid::Generator.new

--- a/spec/examples/record/record_set_spec.rb
+++ b/spec/examples/record/record_set_spec.rb
@@ -462,6 +462,7 @@ describe Cequel::Record::RecordSet do
 
   describe '#after' do
     let(:records) { [posts, published_posts] }
+    let(:published_at_uuid) { published_posts[2].published_at }
 
     it 'should return collection after given key' do
       expect(Post['cassandra'].after('cequel1').map(&:title)).
@@ -471,6 +472,11 @@ describe Cequel::Record::RecordSet do
     it 'should cast argument' do
       expect(Post['cassandra'].after('cequel1'.force_encoding('ASCII-8BIT')).
         map(&:title)).to eq((2...5).map { |i| "Cequel #{i}" })
+    end
+
+    it 'should query Time range for Timeuuid key with Timeuuid argument' do
+      expect(PublishedPost['cassandra'].after(published_at_uuid).map(&:permalink)).
+        to eq(%w(cequel4 cequel3))
     end
 
     it 'should query Time range for Timeuuid key' do
@@ -505,6 +511,7 @@ describe Cequel::Record::RecordSet do
 
   describe '#before' do
     let(:records) { [posts, published_posts] }
+    let(:published_at_uuid) { published_posts[3].published_at }
 
     it 'should return collection before given key' do
       expect(Post['cassandra'].before('cequel3').map(&:title)).
@@ -513,6 +520,11 @@ describe Cequel::Record::RecordSet do
 
     it 'should query Time range for Timeuuid key' do
       expect(PublishedPost['cassandra'].before(now - 1.minute).map(&:permalink)).
+        to eq(%w(cequel2 cequel1 cequel0))
+    end
+
+    it 'should query Time range for Timeuuid key with Timeuuid argument' do
+      expect(PublishedPost['cassandra'].before(published_at_uuid).map(&:permalink)).
         to eq(%w(cequel2 cequel1 cequel0))
     end
 


### PR DESCRIPTION
Before this fix, range query argument value was compared with `Cassandra::Uuid`, so it was not possible to pass `timeuuid` as a string. It was not packed in mentioned class and cequel gem tried to parse it as a `Time`, which was giving `ArgumentError: argument out of range`. 

```
          elsif column.type?(:timeuuid) && !Cequel.uuid?(value)
            TimeuuidBound
```

https://github.com/cequel/cequel/blob/master/lib/cequel/record/bound.rb#L27-L38

Now queries that have `timeuuid` in string argument are working. Example from specs:

```
> before = Cassandra::Uuid::Generator.new.now.to_s
 => "31974816-c49e-11e7-b55e-1b9ba15056b7"
> PublishedPost['cassandra'].before(before)
=> # records published before  2017-11-08 16:02:17 UTC
```
