### PR TITLE
order list item deletes to avoid failures in cassandra

### DIFF
--- a/lib/cequel/metal/data_set.rb
+++ b/lib/cequel/metal/data_set.rb
@@ -289,7 +289,9 @@ module Cequel
       #
       def list_remove_at(column, *positions)
         options = positions.extract_options!
-        deleter { list_remove_at(column, *positions) }.execute(options)
+        sorted_positions = positions.sort.reverse
+
+        deleter { list_remove_at(column, *sorted_positions) }.execute(options)
       end
 
       #


### PR DESCRIPTION
In c* 2.2.10 and 3.11.0 some changes where made to the way deleting items for lists work. This change accommodates those changes.