### PR TITLE
ActiveModel 5.2 Support

### DIFF
--- a/lib/cequel/record/dirty.rb
+++ b/lib/cequel/record/dirty.rb
@@ -47,7 +47,12 @@ module Cequel
       def save(options = {})
         super.tap do |success|
           if success
-            changes_applied
+            if self.respond_to?(:changes_applied)
+              changes_applied
+            else
+              @previously_changed = changes
+              @changed_attributes.clear
+            end
           end
         end
       end

--- a/lib/cequel/record/dirty.rb
+++ b/lib/cequel/record/dirty.rb
@@ -47,8 +47,7 @@ module Cequel
       def save(options = {})
         super.tap do |success|
           if success
-            @previously_changed = changes
-            @changed_attributes.clear
+            changes_applied
           end
         end
       end

--- a/lib/cequel/record/persistence.rb
+++ b/lib/cequel/record/persistence.rb
@@ -82,7 +82,7 @@ module Cequel
       # @since 1.0.0
       #
       def key_attributes
-        @attributes.slice(*self.class.key_column_names)
+        @cequel_attributes.slice(*self.class.key_column_names)
       end
 
       #
@@ -160,7 +160,7 @@ module Cequel
       # @since 1.0.0
       #
       def loaded?(column = nil)
-        !!@loaded && (column.nil? || @attributes.key?(column.to_sym))
+        !!@loaded && (column.nil? || @cequel_attributes.key?(column.to_sym))
       end
 
       #
@@ -361,17 +361,17 @@ module Cequel
       end
 
       def attributes_for_create
-        @attributes.each_with_object({}) do |(column, value), attributes|
+        @cequel_attributes.each_with_object({}) do |(column, value), attributes|
           attributes[column] = value unless value.nil?
         end
       end
 
       def attributes_for_update
-        @attributes_for_update ||= {}
+        @cequel_attributes_for_update ||= {}
       end
 
       def attributes_for_deletion
-        @attributes_for_deletion ||= []
+        @cequel_attributes_for_deletion ||= []
       end
 
       def assert_keys_present!

--- a/lib/cequel/record/properties.rb
+++ b/lib/cequel/record/properties.rb
@@ -281,7 +281,7 @@ module Cequel
 
       # @private
       def initialize(attributes = {}, record_collection = nil)
-        @attributes, @record_collection = attributes, record_collection
+        @cequel_attributes, @record_collection = attributes, record_collection
         @collection_proxies = {}
       end
 
@@ -289,7 +289,7 @@ module Cequel
       # @return [Array<Symbol>] list of names of attributes on this record
       #
       def attribute_names
-        @attributes.keys
+        @cequel_attributes.keys
       end
 
       #
@@ -367,7 +367,7 @@ module Cequel
       protected
 
       def read_attribute(name)
-        @attributes.fetch(name)
+        @cequel_attributes.fetch(name)
       rescue KeyError
         if self.class.reflect_on_column(name)
           fail MissingAttributeError, "missing attribute: #{name}"
@@ -382,7 +382,7 @@ module Cequel
         end
 
         send("#{name}_will_change!") unless value === read_attribute(name)
-        @attributes[name] = value
+        @cequel_attributes[name] = value
       end
 
       private
@@ -397,14 +397,14 @@ module Cequel
       end
 
       def init_attributes(new_attributes)
-        @attributes = {}
+        @cequel_attributes = {}
         new_attributes.each_pair do |name, value|
           if value.nil?
             value = empty_attributes.fetch(name.to_sym) { -> {} }.call
           end
-          @attributes[name.to_sym] = value
+          @cequel_attributes[name.to_sym] = value
         end
-        @attributes
+        @cequel_attributes
       end
 
       def initialize_new_record(attributes = {})

--- a/lib/cequel/record/record_set.rb
+++ b/lib/cequel/record/record_set.rb
@@ -123,7 +123,7 @@ module Cequel
       #
       def initialize(target_class, attributes = {})
         attributes = self.class.default_attributes.merge!(attributes)
-        @target_class, @attributes = target_class, attributes
+        @target_class, @cequel_attributes = target_class, attributes
         super(target_class)
       end
 
@@ -705,10 +705,20 @@ module Cequel
         entries
       end
 
-      protected
+      def attributes
+        cequel_attributes
+      end
 
-      attr_reader :attributes
-      hattr_reader :attributes, :select_columns, :scoped_key_values,
+      def attributes=(attrs)
+        self.cequel_attributes = attr
+      end
+
+
+      attr_accessor :cequel_attributes
+
+      protected
+      
+      hattr_reader :cequel_attributes, :select_columns, :scoped_key_values,
                    :row_limit, :lower_bound, :upper_bound,
                    :scoped_indexed_column, :query_consistency,
                    :query_page_size, :query_paging_state,

--- a/lib/cequel/record/scoped.rb
+++ b/lib/cequel/record/scoped.rb
@@ -60,7 +60,7 @@ module Cequel
 
       def initialize_new_record(*)
         super
-        @attributes.merge!(self.class.current_scope.scoped_key_attributes)
+        @cequel_attributes.merge!(self.class.current_scope.scoped_key_attributes)
       end
     end
   end

--- a/lib/cequel/version.rb
+++ b/lib/cequel/version.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
 module Cequel
   # The current version of the library
-  VERSION = '3.0.2'
+  VERSION = '3.0.3'
 end


### PR DESCRIPTION
This is based on the existing pull request #392, and includes a fix for the Travis-CI build errors against ActiveModel 4.0. 

Alternatively, one could just drop support for 4.0. 