### PR TITLE
Remove deprecated has_rdoc

### DIFF
--- a/cequel.gemspec
+++ b/cequel.gemspec
@@ -24,7 +24,6 @@ DESC
 
   s.files = Dir['lib/**/*.rb', 'templates/**/*', 'spec/**/*.rb', '[A-Z]*']
   s.test_files = Dir['spec/examples/**/*.rb']
-  s.has_rdoc = true
   s.extra_rdoc_files = 'README.md'
   s.required_ruby_version = '>= 2.0'
   s.add_runtime_dependency 'activemodel', '>= 4.0'


### PR DESCRIPTION
has_rdoc has been deprecated for 9 years now.  It causes a warning during `bundle install` - "Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01".

I think it was first deprecated here https://blog.rubygems.org/2009/05/04/1.3.3-released.html, and rubygems started warning about it here https://blog.rubygems.org/2011/03/28/1.7.0-released.html

How about removing it?