### PR TITLE
Support for Rails 5.2 and fixes noisy logs in Ruby 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
+## 3.0.4
+* Add Dockerfile and docker-compose.yml for use in development of the gem.
+* Fix noisy logs from Ruby 2.5, ActiveModel 5.2 compatibility.
+
+## 3.0.3
+* Fix problem with source reload creating duplicate finder methods (find_by_id_and_id) [Issue 206](https://github.com/cequel/cequel/issues/206)
+* Fix problems with noisy logs in Ruby 2.4+ [Issue 373](https://github.com/cequel/cequel/issues/373)
+
 ## 3.0.2
-- support rails 5.1 (https://github.com/cequel/cequel/pull/389)
-- various small changes
+* Support rails 5.1 (https://github.com/cequel/cequel/pull/389)
+* Various small changes
 
 ## 3.0.1
-- fix list modification bug with Cassandra versions > 2.2.10 and 3.11.0
+* fix list modification bug with Cassandra versions > 2.2.10 and 3.11.0
 
 ## 3.0.0
 * Drop support for changing the type of cluster keys as it is no longer support by Cassandra.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,19 @@ bundle exec rake test
 Cequel's test suite runs against a live Cassandra instance. The easiest way to
 get one is to use Docker, `docker run --rm -p 9042:9042 cassandra`.
 
+### Using Docker Compose
+ Cequel's test suite, including a development bash environment, container, and Cassandra
+instance is setup for use through Docker Compose.
+ The local folder is mapped into the docker container. So, you can use your IDE of choice
+to make edits, leveraging the docker-compose to provide Cassandra and an lightweight container for
+running tests.
+ To use, update the docker-compose.yml with your personal details (for Git compatibility) and then:
+```bash
+docker-compose run dev
+```
+This will drop you to a bash prompt in the /cequel/ folder.  From there, you can run
+tests using familiar RSpec commands.
+
 ### Using different ports
 
 You can configure the cequel test suite to use a different port by setting the `CEQUEL_TEST_PORT` environment variable. Example:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ruby:alpine
+WORKDIR /cequel
+# Since this is a docker container to aid with development, we simply copy the entire repo versus caching
+# the gems
+COPY . /cequel/
+RUN apk add --update build-base postgresql-dev tzdata bash bash-completion git \
+    && rm -rf /var/cache/apk/* \
+    # makes it nicer to run tests.. now "ber" instead of "bundle exec rspec" and "bi" instead of "bundle install"
+    && echo 'alias ber="bundle exec rspec"' >> ~/.bashrc \
+    && echo 'alias bi="bundle install"' >> ~/.bashrc \
+    && gem install bundler \
+    && bundle install

--- a/README.md
+++ b/README.md
@@ -595,6 +595,8 @@ you require this functionality.
 
 ### Rails ###
 
+* 5.2
+* 5.1
 * 5.0
 * 4.2
 * 4.1
@@ -602,7 +604,7 @@ you require this functionality.
 
 ### Ruby ###
 
-* Ruby 2.3, 2.2, 2.1, 2.0
+* Ruby 2.5, 2.4, 2.3, 2.2, 2.1, 2.0
 
 ### Cassandra ###
 

--- a/cequel.gemspec
+++ b/cequel.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
     'Ilya Bazylchuk', 'Dan Cardamore', 'Kei Kusakari', 'Oleh Novosad',
     'John Smart', 'Angelo Lakra', 'Olivier Lance', 'Tomohiro Nishimura',
     'Masaki Takahashi', 'G Gordon Worley III', 'Clark Bremer', 'Tamara Temple',
-    'Long On', 'Lucas Mundim'
+    'Long On', 'Lucas Mundim', 'William Flanagan', 'Inaki Lanusse'
   ]
   s.homepage = "https://github.com/cequel/cequel"
   s.email = 'mat.a.brown@gmail.com'
@@ -24,7 +24,6 @@ DESC
 
   s.files = Dir['lib/**/*.rb', 'templates/**/*', 'spec/**/*.rb', '[A-Z]*']
   s.test_files = Dir['spec/examples/**/*.rb']
-  s.extra_rdoc_files = 'README.md'
   s.required_ruby_version = '>= 2.0'
   s.add_runtime_dependency 'activemodel', '>= 4.0'
   s.add_runtime_dependency 'cassandra-driver', '~> 3.0'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.6'
+volumes:
+  bundle_cache:
+  cassandra:
+    driver: local
+services:
+  dev:
+    build: .
+    volumes:
+      - ./:/cequel
+    environment:
+      - "CEQUEL_TEST_HOST=cassandra"
+      - "GIT_AUTHOR_NAME=YourAuthorName"
+      - "GIT_AUTHOR_EMAIL=YourAuthor@email.com"
+      - "EMAIL=YourAuthor@email.com"
+    working_dir: /cequel
+    stdin_open: true
+    tty: true
+    command: bash
+    links:
+      - cassandra
+  cassandra:
+    image: smizy/cassandra:3.11-alpine
+    volumes:
+      - cassandra:/var/lib/cassandra

--- a/lib/cequel/metal/batch_manager.rb
+++ b/lib/cequel/metal/batch_manager.rb
@@ -55,13 +55,13 @@ module Cequel
         end
       end
 
-      private
-
-      attr_reader :keyspace
-
       def current_batch
         ::Thread.current[batch_key]
       end
+
+      private
+
+      attr_reader :keyspace
 
       def current_batch=(batch)
         ::Thread.current[batch_key] = batch

--- a/lib/cequel/record/associations.rb
+++ b/lib/cequel/record/associations.rb
@@ -99,7 +99,7 @@ module Cequel
         # @see Associations
         #
         def belongs_to(name, options = {})
-          if parent_association
+          if parent_association && !self.parent_association.name == name.to_sym
             fail InvalidRecordConfiguration,
                  "Can't declare more than one belongs_to association"
           end
@@ -146,8 +146,6 @@ module Cequel
           def_child_association_reader(association)
         end
 
-        private
-
         def def_parent_association_accessors
           def_parent_association_reader
           def_parent_association_writer
@@ -188,7 +186,7 @@ module Cequel
         end
       end
 
-      private
+      protected
 
       def read_parent_association
         ivar_name = parent_association.instance_variable_name
@@ -226,6 +224,8 @@ module Cequel
             write_attribute(column_name, value)
           end
       end
+
+      private
 
       def read_child_association(association_name, reload = false)
         association = child_associations[association_name]

--- a/lib/cequel/record/data_set_builder.rb
+++ b/lib/cequel/record/data_set_builder.rb
@@ -48,14 +48,14 @@ module Cequel
 
       protected
 
+      def record_set_delegated_methods
+        %i[ row_limit select_columns scoped_key_names scoped_key_values
+            scoped_indexed_column lower_bound upper_bound reversed? order_by_column
+            query_consistency query_page_size query_paging_state ascends_by? allow_filtering ]
+      end
+
       attr_accessor :data_set
       attr_reader :record_set
-      def_delegators :record_set, :row_limit, :select_columns,
-                     :scoped_key_names, :scoped_key_values,
-                     :scoped_indexed_column, :lower_bound,
-                     :upper_bound, :reversed?, :order_by_column,
-                     :query_consistency, :query_page_size, :query_paging_state,
-                     :ascends_by?, :allow_filtering
 
       private
 
@@ -121,6 +121,14 @@ module Cequel
 
       def sort_direction
         ascends_by?(order_by_column) ? :asc : :desc
+      end
+
+      def method_missing(m, *args, &block)
+        if record_set_delegated_methods.include?(m)
+          record_set.send(m, *args, &block)
+        else
+          super
+        end
       end
     end
   end

--- a/lib/cequel/record/dirty.rb
+++ b/lib/cequel/record/dirty.rb
@@ -47,8 +47,12 @@ module Cequel
       def save(options = {})
         super.tap do |success|
           if success
-            @previously_changed = changes
-            @changed_attributes.clear
+            if self.respond_to?(:changes_applied)
+              changes_applied
+            else
+              @previously_changed = changes
+              @changed_attributes.clear
+            end
           end
         end
       end

--- a/lib/cequel/record/lazy_record_collection.rb
+++ b/lib/cequel/record/lazy_record_collection.rb
@@ -19,9 +19,6 @@ module Cequel
       #   (see RecordSet#table)
       # @!method connection
       #   (see RecordSet#connection)
-      def_delegators :record_set, :table, :connection
-
-      #
       # @param record_set [RecordSet] record set representing the records in
       #   this collection
       # @api private
@@ -77,11 +74,20 @@ module Cequel
 
       attr_reader :record_set
 
-      def_delegators :record_set, :key_columns, :scoped_key_values
-      private :key_columns, :scoped_key_values
-
       def key_attributes_for_each_row
         map { |record| record.key_attributes }
+      end
+
+      def record_set_delegated_methods
+        %i[table connection key_columns scoped_key_values]
+      end
+      
+      def method_missing(m, *args, &block)
+        if record_set_delegated_methods.include?(m)
+          record_set.send(m, *args, &block)
+        else
+          super
+        end
       end
     end
   end

--- a/lib/cequel/record/persistence.rb
+++ b/lib/cequel/record/persistence.rb
@@ -82,7 +82,7 @@ module Cequel
       # @since 1.0.0
       #
       def key_attributes
-        @attributes.slice(*self.class.key_column_names)
+        @cequel_attributes.slice(*self.class.key_column_names)
       end
 
       #
@@ -160,7 +160,7 @@ module Cequel
       # @since 1.0.0
       #
       def loaded?(column = nil)
-        !!@loaded && (column.nil? || @attributes.key?(column.to_sym))
+        !!@loaded && (column.nil? || @cequel_attributes.key?(column.to_sym))
       end
 
       #
@@ -185,8 +185,10 @@ module Cequel
       #
       def save(options = {})
         options.assert_valid_keys(:consistency, :ttl, :timestamp)
-        if new_record? then create(options)
-        else update(options)
+        if new_record?
+          create(options)
+        else
+          update(options)
         end
         @new_record = false
         true
@@ -260,6 +262,16 @@ module Cequel
         self
       end
 
+      def updater
+        raise ArgumentError, "Can't get updater for new record" if new_record?
+        @updater ||= Metal::Updater.new(metal_scope)
+      end
+
+      def deleter
+        raise ArgumentError, "Can't get deleter for new record" if new_record?
+        @deleter ||= Metal::Deleter.new(metal_scope)
+      end
+
       protected
 
       def persisted!
@@ -290,16 +302,6 @@ module Cequel
         end
       end
       instrument :update, data: ->(rec) { {table_name: rec.table_name} }
-
-      def updater
-        raise ArgumentError, "Can't get updater for new record" if new_record?
-        @updater ||= Metal::Updater.new(metal_scope)
-      end
-
-      def deleter
-        raise ArgumentError, "Can't get deleter for new record" if new_record?
-        @deleter ||= Metal::Deleter.new(metal_scope)
-      end
 
       private
 
@@ -361,17 +363,17 @@ module Cequel
       end
 
       def attributes_for_create
-        @attributes.each_with_object({}) do |(column, value), attributes|
+        @cequel_attributes.each_with_object({}) do |(column, value), attributes|
           attributes[column] = value unless value.nil?
         end
       end
 
       def attributes_for_update
-        @attributes_for_update ||= {}
+        @cequel_attributes_for_update ||= {}
       end
 
       def attributes_for_deletion
-        @attributes_for_deletion ||= []
+        @cequel_attributes_for_deletion ||= []
       end
 
       def assert_keys_present!

--- a/lib/cequel/record/properties.rb
+++ b/lib/cequel/record/properties.rb
@@ -281,7 +281,7 @@ module Cequel
 
       # @private
       def initialize(attributes = {}, record_collection = nil)
-        @attributes, @record_collection = attributes, record_collection
+        @cequel_attributes, @record_collection = attributes, record_collection
         @collection_proxies = {}
       end
 
@@ -289,7 +289,7 @@ module Cequel
       # @return [Array<Symbol>] list of names of attributes on this record
       #
       def attribute_names
-        @attributes.keys
+        @cequel_attributes.keys
       end
 
       #
@@ -367,7 +367,7 @@ module Cequel
       protected
 
       def read_attribute(name)
-        @attributes.fetch(name)
+        @cequel_attributes.fetch(name)
       rescue KeyError
         if self.class.reflect_on_column(name)
           fail MissingAttributeError, "missing attribute: #{name}"
@@ -382,7 +382,7 @@ module Cequel
         end
 
         send("#{name}_will_change!") unless value === read_attribute(name)
-        @attributes[name] = value
+        @cequel_attributes[name] = value
       end
 
       private
@@ -397,14 +397,14 @@ module Cequel
       end
 
       def init_attributes(new_attributes)
-        @attributes = {}
+        @cequel_attributes = {}
         new_attributes.each_pair do |name, value|
           if value.nil?
             value = empty_attributes.fetch(name.to_sym) { -> {} }.call
           end
-          @attributes[name.to_sym] = value
+          @cequel_attributes[name.to_sym] = value
         end
-        @attributes
+        @cequel_attributes
       end
 
       def initialize_new_record(attributes = {})

--- a/lib/cequel/record/record_set.rb
+++ b/lib/cequel/record/record_set.rb
@@ -123,7 +123,7 @@ module Cequel
       #
       def initialize(target_class, attributes = {})
         attributes = self.class.default_attributes.merge!(attributes)
-        @target_class, @attributes = target_class, attributes
+        @target_class, @cequel_attributes = target_class, attributes
         super(target_class)
       end
 
@@ -705,19 +705,25 @@ module Cequel
         entries
       end
 
+      def attributes
+        cequel_attributes
+      end
+      
+      def attributes=(attrs)
+        self.cequel_attributes = attrs
+      end
+      
+      attr_accessor :cequel_attributes
+
       protected
 
-      attr_reader :attributes
-      hattr_reader :attributes, :select_columns, :scoped_key_values,
+      hattr_reader :cequel_attributes, :select_columns, :scoped_key_values,
                    :row_limit, :lower_bound, :upper_bound,
                    :scoped_indexed_column, :query_consistency,
                    :query_page_size, :query_paging_state,
                    :allow_filtering
-      protected :select_columns, :scoped_key_values, :row_limit, :lower_bound,
-                :upper_bound, :scoped_indexed_column, :query_consistency,
-                :query_page_size, :query_paging_state, :allow_filtering
+
       hattr_inquirer :attributes, :reversed
-      protected :reversed?
 
       def next_batch_from(row)
         range_key_value = row[range_key_name]
@@ -941,9 +947,10 @@ module Cequel
         end
       end
 
+      def_delegators :target_class, :connection
+
       private
 
-      def_delegators :target_class, :connection
       def_delegator :range_key_column, :cast, :cast_range_key
       private :connection, :cast_range_key
 

--- a/lib/cequel/record/scoped.rb
+++ b/lib/cequel/record/scoped.rb
@@ -60,7 +60,7 @@ module Cequel
 
       def initialize_new_record(*)
         super
-        @attributes.merge!(self.class.current_scope.scoped_key_attributes)
+        @cequel_attributes.merge!(self.class.current_scope.scoped_key_attributes)
       end
     end
   end

--- a/lib/cequel/schema/table.rb
+++ b/lib/cequel/schema/table.rb
@@ -13,21 +13,6 @@ module Cequel
       # @return [Symbol] the name of the table
       attr_reader :name
 
-      # @return [Array<Column>] all columns defined on the table
-      attr_reader :columns
-
-      # @return [Array<PartitionKey>] partition key columns defined on the
-      #   table
-      attr_reader :partition_key_columns
-
-      # @return [Array<ClusteringColumn>] clustering columns defined on the
-      #   table
-      attr_reader :clustering_columns
-
-      # @return [Array<DataColumn,CollectionColumn>] data columns and
-      #   collection columns defined on the table
-      attr_reader :data_columns
-
       # @return [Hash] storage properties defined on the table
       attr_reader :properties
 
@@ -42,8 +27,6 @@ module Cequel
       def initialize(name, is_view=false)
         @name = name.to_sym
         @is_view = is_view
-        @partition_key_columns, @clustering_columns, @data_columns = [], [], []
-        @columns, @columns_by_name = [], {}
         @properties = ActiveSupport::HashWithIndifferentAccess.new
       end
 
@@ -52,24 +35,79 @@ module Cequel
         @is_view
       end
 
+      # Manages the columns by name that have been added to the
+      # table. Uses the hash to create a unique value for this attribute.
+      # The last one loaded in the source load will be the definition
+      # of the column.
+      def columns_by_name
+        @columns_by_name ||= {}
+      end
+
+      # Accessor for the column values on the @columns_by_name hash
+      # used to gain access to the column names.
+      def columns
+        columns_by_name.values
+      end
+
+      # Manages the partition key columns that have been added to the
+      # table. Uses the hash to create a unique value for this attribute.
+      # Similar to columns, the last one loaded in the source load will be
+      # the definition of the column.
+      def partition_key_columns_hash
+        @partition_key_columns_hash ||= {}
+      end
+
+      # Provides an accessor for the partition_key_columns as an array
+      def partition_key_columns
+        partition_key_columns_hash.values
+      end
+
+      # Manages the clustering key columns that have been added to the
+      # table. Uses the hash to create a unique value for this attribute.
+      # Similar to columns, the last one loaded in the source load will be
+      # the definition of the column.
+      def clustering_columns_hash
+        @clustering_columns_hash ||= {}
+      end
+
+      # Provides an accessor for the clustering_key_columns as an array
+      def clustering_columns
+        clustering_columns_hash.values
+      end
+
+      # Manages the data key columns that have been added to the
+      # table. Uses the hash to create a unique value for this attribute.
+      # Similar to columns, the last one loaded in the source load will be
+      # the definition of the column.
+      def data_columns_hash
+        @data_columns_hash ||= {}
+      end
+
+       # Provides an accessor for the data_key_columns as an array
+      def data_columns
+        data_columns_hash.values
+      end
+
       # Add a column descriptor to this table descriptor.
       #
       # column_desc - Descriptor of column to add. Can be PartitionKey,
       #   ClusteringColumn, DataColumn, List, Set, or Map.
       #
       def add_column(column_desc)
-        column_flavor = case column_desc
-                        when PartitionKey
-                          @partition_key_columns
-                        when ClusteringColumn
-                          @clustering_columns
-                        else
-                          @data_columns
-                        end
-
-        column_flavor << column_desc
-        columns << column_desc
+        column_description_store(column_desc)[column_desc.name] = column_desc
         columns_by_name[column_desc.name] = column_desc
+      end
+
+      # Stores the column description in the appropriate storage hash
+      # for the column name and column type.
+      def column_description_store(column_desc)
+        if partition_key?(column_desc)
+          partition_key_columns_hash
+        elsif clustering_column?(column_desc)
+          clustering_columns_hash
+        else
+          data_columns_hash
+        end
       end
 
       # Add a property to this table descriptor
@@ -143,6 +181,12 @@ module Cequel
         partition_key_columns.any?
       end
 
+      # Returns true iff the column descriptor is a partition key
+      #
+      def partition_key?(column_desc)
+        column_desc.class == Cequel::Schema::PartitionKey
+      end
+
       #
       # @return [Array<Symbol>] names of clustering columns
       #
@@ -173,6 +217,12 @@ module Cequel
         clustering_columns.find { |column| column.name == name }
       end
 
+      # Returns true iff the column descriptor is a clustering column
+      #
+      def clustering_column?(column_desc)
+        column_desc.class == Cequel::Schema::ClusteringColumn
+      end
+
       #
       # @param name [Symbol] name of data column to look up
       # @return [DataColumn,CollectionColumn] data column or collection column
@@ -200,11 +250,8 @@ module Cequel
 
       protected
 
-      attr_reader :columns_by_name
-
       def type(type)
         type = type.kind if type.respond_to?(:kind)
-
         ::Cequel::Type[type]
       end
 

--- a/lib/cequel/version.rb
+++ b/lib/cequel/version.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
 module Cequel
   # The current version of the library
-  VERSION = '3.0.2'
+  VERSION = '3.0.4'
 end

--- a/spec/examples/record/list_spec.rb
+++ b/spec/examples/record/list_spec.rb
@@ -3,9 +3,9 @@ require File.expand_path('../spec_helper', __FILE__)
 
 describe Cequel::Record::List do
   model :Post do
-    key :permalink, :text
-    column :title, :text
-    list :tags, :text
+    key :permalink,        :text
+    column :title,         :text
+    list :tags,            :text
     list :contributor_ids, :int
   end
 


### PR DESCRIPTION
## Summary
So I added some finishing touches on great work by @wflanagan, @bmurray, and @erkie in PR #378.
This should be enough to cover both that PR and #395.

## Features
- Removes noisy logs in Ruby 2.5 by changing a few protection levels. I played around with them to see  if changing protection levels could be avoided but no such luck. This seems the way to go.
- Adds support for Rails 5.2