### PR TITLE
Can now query with ALLOW FILTERING for multiple non-indexed columns

### DIFF
--- a/lib/cequel/record/record_set.rb
+++ b/lib/cequel/record/record_set.rb
@@ -846,7 +846,7 @@ module Cequel
                "Can't scope key column #{column_name} without also scoping " \
                "#{missing_column_names.join(', ')}"
         end
-        if scoped_indexed_column
+        if scoped_indexed_column && !allow_filtering
           fail IllegalQuery,
                "Can't scope by more than one indexed column in the same query"
         end

--- a/spec/examples/record/record_set_spec.rb
+++ b/spec/examples/record/record_set_spec.rb
@@ -819,8 +819,15 @@ describe Cequel::Record::RecordSet do
     end
 
     context 'allow_filtering!', cql: '~> 3.4' do
-      it 'should allow filtering for none indexed columns' do
+      it 'should allow filtering for non-indexed columns' do
         expect(Post.allow_filtering!.where(title: 'Cequel 0').entries.length).to be(1)
+      end
+
+      it 'should allow filtering for more than one non-indexed column' do
+        expect(Post.allow_filtering!.where(
+          title: 'Cequel 0',
+          body: 'Post number 0'
+        ).entries.length).to be(1)
       end
     end
   end


### PR DESCRIPTION
## Summary
Can now query for more than one non-indexed column when allow filtering is active.

## Reason
Ran into a problem where I was looking to filter by more than one column within a table. Since most partitions would have only a few hundred tuples, I decided to use allow filtering, since it probably wouldn't lead to memory failure. I am backed by `cassandra-stress` results. 

I tried to query this way through Cequel but I got an `IllegalQuery` exception. I tried it out in CQL:

<img width="506" alt="screen shot 2018-11-28 at 13 24 16" src="https://user-images.githubusercontent.com/5209518/49167308-e6635d80-f313-11e8-97fc-f8ae6092ee06.png">
<img width="1156" alt="screen shot 2018-11-28 at 13 20 44" src="https://user-images.githubusercontent.com/5209518/49167350-f67b3d00-f313-11e8-959a-3e239c05634b.png">

As you can see, once allow filtering is declared, then queries by more than one non-indexed columns are legal in CQL.

So I decided to add this in Cequel! Hence this PR.