### PR TITLE
Fixed CodeClimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,5 @@
 ---
-engines:
+plugins:
   duplication:
     enabled: true
     config:
@@ -7,9 +7,4 @@ engines:
       - ruby
   rubocop:
     enabled: true
-    
-ratings:
-  paths:
-  - "**.rb"
-
-exclude_paths: 
+version: 2


### PR DESCRIPTION
## Summary
I wanted to fix the CodeClimate configuration so I just went ahead and did that.

I downloaded the CodeClimate CLI and ran the validator:

<img width="599" alt="screen shot 2019-01-02 at 14 58 51" src="https://user-images.githubusercontent.com/5209518/50605016-b9204700-0e9f-11e9-9f70-4e2cb806ef21.png">

So I renamed `engines` to `plugins`, removed the empty `exclude_paths`, and removed `ratings`. Not to worry, as communicated [here](https://docs.codeclimate.com/docs/advanced-configuration), "all files in our supported languages for maintainability will receive maintainability ratings by default."

Then we got an error because no version was specified. Once that was over, smooth sailing:

<img width="452" alt="screen shot 2019-01-02 at 15 08 33" src="https://user-images.githubusercontent.com/5209518/50605187-4e234000-0ea0-11e9-8083-fc13b1e8d505.png">
