### PR TITLE
Fixed a bug where multiple non-indexed column filtering was not working

### DIFF
--- a/lib/cequel/record/data_set_builder.rb
+++ b/lib/cequel/record/data_set_builder.rb
@@ -52,7 +52,7 @@ module Cequel
       attr_reader :record_set
       def_delegators :record_set, :row_limit, :select_columns,
                      :scoped_key_names, :scoped_key_values,
-                     :scoped_indexed_column, :lower_bound,
+                     :scoped_secondary_columns, :lower_bound,
                      :upper_bound, :reversed?, :order_by_column,
                      :query_consistency, :query_page_size, :query_paging_state,
                      :ascends_by?, :allow_filtering
@@ -72,8 +72,8 @@ module Cequel
           key_conditions = Hash[scoped_key_names.zip(scoped_key_values)]
           self.data_set = data_set.where(key_conditions)
         end
-        if scoped_indexed_column
-          self.data_set = data_set.where(scoped_indexed_column)
+        if scoped_secondary_columns
+          self.data_set = data_set.where(scoped_secondary_columns)
         end
       end
 

--- a/spec/examples/record/record_set_spec.rb
+++ b/spec/examples/record/record_set_spec.rb
@@ -13,6 +13,7 @@ describe Cequel::Record::RecordSet do
     key :permalink, :ascii
     column :title, :text
     column :body, :text
+    column :subtitle, :text
     column :author_id, :uuid, index: true
     column :author_name, :text, index: true
     list :tags, :text
@@ -54,11 +55,12 @@ describe Cequel::Record::RecordSet do
   let(:cassandra_posts) do
     5.times.map do |i|
       Post.new(
-        :blog_subdomain => 'cassandra',
-        :permalink => "cequel#{i}",
-        :title => "Cequel #{i}",
-        :body => "Post number #{i}",
-        :author_id => uuids[i%2]
+        blog_subdomain: 'cassandra',
+        permalink: "cequel#{i}",
+        title: "Cequel #{i}",
+        subtitle: 'New Cequel Post',
+        body: "Post number #{i}",
+        author_id: uuids[i%2]
       )
     end
   end
@@ -826,7 +828,7 @@ describe Cequel::Record::RecordSet do
       it 'should allow filtering for more than one non-indexed column' do
         expect(Post.allow_filtering!.where(
           title: 'Cequel 0',
-          body: 'Post number 0'
+          subtitle: 'New Cequel Post'
         ).entries.length).to be(1)
       end
     end


### PR DESCRIPTION
## Summary
Remember https://github.com/cequel/cequel/pull/404/? It turns out it was badly tested and thus I couldn't see that the filters would replace the previous filter since they weren't merging together in `filter_secondary_index` (which I renamed to something I feel is more accurate: `filter_secondary_column`).

So I found the bug while doing QA on a project of mine, here's the fix.

I'm sorry I haven't been able to work on the UDT PR but things have been hectic at work these past few weeks. I'll have some time in a couple of weeks.

Cheers!