### PR TITLE
Use bind_var with ttl to allow correctly generated prepared statements.

### DIFF
--- a/lib/cequel/metal/deleter.rb
+++ b/lib/cequel/metal/deleter.rb
@@ -71,7 +71,7 @@ module Cequel
             .append(statements.join(','), *bind_vars)
             .append(" FROM #{table_name}")
         end
-        statement.append(generate_upsert_options(options))
+        statement.append(*generate_upsert_options(options))
       end
 
       def empty?

--- a/lib/cequel/metal/incrementer.rb
+++ b/lib/cequel/metal/incrementer.rb
@@ -38,7 +38,7 @@ module Cequel
       def write_to_statement(statement, options)
         statement
           .append("UPDATE #{table_name}")
-          .append(generate_upsert_options(options))
+          .append(*generate_upsert_options(options))
           .append(
             " SET " << statements.join(', '),
             *bind_vars

--- a/lib/cequel/metal/inserter.rb
+++ b/lib/cequel/metal/inserter.rb
@@ -63,7 +63,7 @@ module Cequel
         statement.append(
           " (#{column_names.join(', ')}) VALUES (#{statements.join(', ')}) ",
           *bind_vars)
-        statement.append(generate_upsert_options(options))
+        statement.append(*generate_upsert_options(options))
       end
     end
   end

--- a/lib/cequel/metal/updater.rb
+++ b/lib/cequel/metal/updater.rb
@@ -148,7 +148,7 @@ module Cequel
       def write_to_statement(statement, options)
         all_statements, all_bind_vars = statements_with_column_updates
         statement.append("UPDATE #{table_name}")
-          .append(generate_upsert_options(options))
+          .append(*generate_upsert_options(options))
           .append(" SET ")
           .append(all_statements.join(', '), *all_bind_vars)
       end

--- a/lib/cequel/metal/writer.rb
+++ b/lib/cequel/metal/writer.rb
@@ -62,7 +62,8 @@ module Cequel
       #
       def generate_upsert_options(options)
         upsert_options = options.slice(:timestamp, :ttl)
-        if upsert_options.empty?
+        bind_vars = []
+        statement = if upsert_options.empty?
           ''
         else
           ' USING ' <<
@@ -70,11 +71,15 @@ module Cequel
             serialized_value =
               case key
               when :timestamp then (value.to_f * 1_000_000).to_i
+              when :ttl
+                bind_vars << value
+                '?'
               else value
               end
             "#{key.to_s.upcase} #{serialized_value}"
           end.join(' AND ')
         end
+        return statement, *bind_vars
       end
     end
   end


### PR DESCRIPTION
TTL is not parametrised in prepared statements
https://github.com/cequel/cequel/issues/376

This leads to:
WARN  [ScheduledTasks:1] 2020-06-29 09:19:28,331 QueryProcessor.java:106 - 129 prepared statements discarded in the last minute because cache limit reached (15 MB)