### PR TITLE
Replace i18n hash refinements with ActiveSupport

### DIFF
--- a/lib/cequel/record/railtie.rb
+++ b/lib/cequel/record/railtie.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-require 'i18n/core_ext/hash'
+require 'active_support/core_ext/hash'
 require 'yaml'
 require 'erb'
 


### PR DESCRIPTION
`i18n => 1.9.0` broke cequel.

https://github.com/ruby-i18n/i18n/pull/573